### PR TITLE
brozzler-new-site: Fix warcprox_meta's default value and json import

### DIFF
--- a/bin/brozzler-new-site
+++ b/bin/brozzler-new-site
@@ -27,6 +27,7 @@ import re
 import rethinkstuff
 import warnings
 import requests
+import json
 
 arg_parser = argparse.ArgumentParser(prog=os.path.basename(__file__),
         description="brozzler-new-site - register site to brozzle",
@@ -63,7 +64,7 @@ site = brozzler.Site(
         time_limit=int(args.time_limit) if args.time_limit else None,
         ignore_robots=args.ignore_robots,
         enable_warcprox_features=args.enable_warcprox_features,
-        warcprox_meta=json.loads(args.warcprox_meta))
+        warcprox_meta=json.loads(args.warcprox_meta) if args.warcprox_meta else None)
 
 r = rethinkstuff.Rethinker(args.rethinkdb_servers.split(","), args.rethinkdb_db)
 frontier = brozzler.RethinkDbFrontier(r)


### PR DESCRIPTION
Just making it so the script can actually run.

I think brozzler-new-site is still partly broken though, the worker crashes complaining that job_id is None. I guess one needs to be passed to Site(). Wasn't sure if it should take a job id as an argument or generate one randomly.

I have since realised that brozzler-new-job is probably what I should be looking at instead but had already patched this so figured I'd submit it anyway just in case. ;-)