### PR TITLE
disable browser extensions

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -458,6 +458,7 @@ class Chrome:
                 "--disable-first-run-ui", "--no-first-run",
                 "--homepage=about:blank", "--disable-direct-npapi-requests",
                 "--disable-web-security", "--disable-notifications",
+                "--disable-extensions",
                 "--disable-save-password-bubble"]
         if self.ignore_cert_errors:
             chrome_args.append("--ignore-certificate-errors")


### PR DESCRIPTION
--disable-extensions keeps Chromium from installing Chrome extensions—lastpass was very troublesome until I added this.

There's a great list of Chromium command line switches here: http://peter.sh/experiments/chromium-command-line-switches/

I'm curious to know why brozzler uses --window-size=1100,900

I'm curious to know wh 