### PR TITLE
Py3 update to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Mac instructions:
     rethinkdb &>>rethinkdb.log &
 
     # install brozzler with special dependencies pywb and warcprox
-    pip install brozzler[easy]  # in a virtualenv if desired
+    pip3 install brozzler[easy]  # in a virtualenv if desired
 
     # queue a site to crawl
     brozzler-new-site http://example.com/
@@ -69,7 +69,7 @@ To install brozzler only:
 
 ::
 
-    pip install brozzler  # in a virtualenv if desired
+    pip3 install brozzler  # in a virtualenv if desired
 
 Launch one or more workers:
 


### PR DESCRIPTION
Per #1 brozzler requires py3.

When I run the command for pip in the README on OS X, I get:
```
Collecting brozzler[easy]
  Using cached brozzler-1.1b5.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/04/3w_t28hj0413fnmf2szpzqsh00010g/T/pip-build-3BBLdS/brozzler/setup.py", line 40, in <module>
        long_description=open('README.rst', encoding='UTF-8').read(),
    TypeError: 'encoding' is an invalid keyword argument for this function
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/04/3w_t28hj0413fnmf2szpzqsh00010g/T/pip-build-3BBLdS/brozzler/
```

Changing the command to pip3 allows brozzler to be installed.