### PR TITLE
obsolete ARI-5008 / ARI-5065 Noah's ExtraHTTPHeaders encoding fix

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -460,7 +460,7 @@ __brzl_compileOutlinks(window).join(' ');
         self.send_to_chrome(method="Runtime.enable")
 
         headers = self.extra_headers or {}
-        headers['Accept-Encoding'] = 'gzip, deflate'
+        headers['Accept-Encoding'] = 'identity'
         self.send_to_chrome(
                 method="Network.setExtraHTTPHeaders",
                 params={"headers":headers})

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -459,8 +459,11 @@ __brzl_compileOutlinks(window).join(' ');
         self.send_to_chrome(method="Debugger.enable")
         self.send_to_chrome(method="Runtime.enable")
 
-        if self.extra_headers:
-            self.send_to_chrome(method="Network.setExtraHTTPHeaders", params={"headers":self.extra_headers})
+        headers = self.extra_headers or {}
+        headers['Accept-Encoding'] = 'gzip, deflate'
+        self.send_to_chrome(
+                method="Network.setExtraHTTPHeaders",
+                params={"headers":headers})
 
         if self.user_agent:
             self.send_to_chrome(method="Network.setUserAgentOverride", params={"userAgent": self.user_agent})

--- a/brozzler/pywb.py
+++ b/brozzler/pywb.py
@@ -63,13 +63,16 @@ class RethinkCDXSource(pywb.cdx.cdxsource.CDXSource):
             # short-circuit this step and create the CDXObject directly
             blob = {
                 'url': record['url'],
-                'mime': record['content_type'],
                 'status': str(record['response_code']),
                 'digest': record['sha1base32'],
                 'length': str(record['length']), # XXX is this the right length?
                 'offset': str(record['offset']),
                 'filename': record['filename'],
             }
+            if record['warc_type'] != 'revisit':
+                blob['mime'] = record['content_type']
+            else:
+                blob['mime'] = 'warc/revisit'
             # b'org,archive)/ 20160427215530 {"url": "https://archive.org/", "mime": "text/html", "status": "200", "digest": "VILUFXZD232SLUA6XROZQIMEVUPW6EIE", "length": "16001", "offset": "90144", "filename": "ARCHIVEIT-261-ONE_TIME-JOB209607-20160427215508135-00000.warc.gz"}'
             cdx_line = '{} {:%Y%m%d%H%M%S} {}'.format(
                     record['canon_surt'], record['timestamp'],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def find_package_data(package):
 
 setuptools.setup(
         name='brozzler',
-        version='1.1b7.dev99',
+        version='1.1b7.dev100',
         description='Distributed web crawling with browsers',
         url='https://github.com/internetarchive/brozzler',
         author='Noah Levitt',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def find_package_data(package):
 
 setuptools.setup(
         name='brozzler',
-        version='1.1b7.dev100',
+        version='1.1b7.dev101',
         description='Distributed web crawling with browsers',
         url='https://github.com/internetarchive/brozzler',
         author='Noah Levitt',

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -138,4 +138,4 @@ def test_brozzle_site(httpd):
     wb_url = 'http://localhost:8880/brozzler/%s/%s' % (t14, page2)
     expected_payload = open(os.path.join(
         os.path.dirname(__file__), 'htdocs', 'file1.txt'), 'rb').read()
-    assert requests.get().content == expected_payload
+    assert requests.get(wb_url).content == expected_payload


### PR DESCRIPTION
The main purpose of this change is to avoid `content-encoding: br` which we were getting from facebook, but is not supported by wayback.