### PR TITLE
Make youtube-dl optional in BrozzlerWorker.brozzle_page

### DIFF
--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -316,30 +316,32 @@ class BrozzlerWorker:
 
         return full_jpeg, thumb_jpeg
 
-    def brozzle_page(self, browser, site, page, on_screenshot=None):
+    def brozzle_page(self, browser, site, page, on_screenshot=None,
+                     enable_youtube_dl=True):
         self.logger.info("brozzling {}".format(page))
-        try:
-            with tempfile.TemporaryDirectory(prefix='brzl-ydl-') as tempdir:
-                ydl = self._youtube_dl(tempdir, site)
-                ydl_spy = ydl.brozzler_spy # remember for later
-                self._try_youtube_dl(ydl, site, page)
-        except brozzler.ReachedLimit as e:
-            raise
-        except brozzler.ShutdownRequested:
-            raise
-        except brozzler.ProxyError:
-            raise
-        except Exception as e:
-            if (hasattr(e, 'exc_info') and len(e.exc_info) >= 2
-                    and hasattr(e.exc_info[1], 'code')
-                    and e.exc_info[1].code == 430):
-                self.logger.info(
-                        'youtube-dl got %s %s processing %s',
-                        e.exc_info[1].code, e.exc_info[1].msg, page.url)
-            else:
-                self.logger.error(
-                        'youtube_dl raised exception on %s', page,
-                        exc_info=True)
+        if enable_youtube_dl:
+            try:
+                with tempfile.TemporaryDirectory(prefix='brzl-ydl-') as tempdir:
+                    ydl = self._youtube_dl(tempdir, site)
+                    ydl_spy = ydl.brozzler_spy # remember for later
+                    self._try_youtube_dl(ydl, site, page)
+            except brozzler.ReachedLimit as e:
+                raise
+            except brozzler.ShutdownRequested:
+                raise
+            except brozzler.ProxyError:
+                raise
+            except Exception as e:
+                if (hasattr(e, 'exc_info') and len(e.exc_info) >= 2
+                        and hasattr(e.exc_info[1], 'code')
+                        and e.exc_info[1].code == 430):
+                    self.logger.info(
+                            'youtube-dl got %s %s processing %s',
+                            e.exc_info[1].code, e.exc_info[1].msg, page.url)
+                else:
+                    self.logger.error(
+                            'youtube_dl raised exception on %s', page,
+                            exc_info=True)
 
         if self._needs_browsing(page, ydl_spy):
             self.logger.info('needs browsing: %s', page)


### PR DESCRIPTION
Enabled by default (of course).
Speed is significantly improved when it is disabled.

## Motivation
<!-- How does this code change improve the world? -->
<!-- Could be a reference to an issue/ticket tracker (like JIRA) if both author and reviewer have access permissions -->

## Description
<!-- What exactly does this do? Could be the git commit message -->

## Testing and Deployment Plan
<!-- Are there automated tests? How can a reviewer verify the change, if applicable? -->
<!-- Any issues forseen deploying this to production? -->


<!-- Don't forget to cc: any person or group who should be aware of this PR, and to assign a reviewer -->
