### PR TITLE
Remove redundant method parameter.

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -376,7 +376,7 @@ class Browser:
         return self.websock_url is not None
 
     def browse_page(
-            self, page_url, ignore_cert_errors=False, extra_headers=None,
+            self, page_url, extra_headers=None,
             user_agent=None, behavior_parameters=None,
             on_request=None, on_response=None, on_screenshot=None,
             username=None, password=None, hashtags=None,


### PR DESCRIPTION
``ignore_cert_errors`` is passed to ``Chrome`` via ``Browser`` via ``BrowserPool` here:
https://github.com/internetarchive/brozzler/blob/master/brozzler/worker.py#L120

it is not doing anything in ``Browser.browser_page``.

## Motivation
<!-- How does this code change improve the world? -->
<!-- Could be a reference to an issue/ticket tracker (like JIRA) if both author and reviewer have access permissions -->

## Description
<!-- What exactly does this do? Could be the git commit message -->

## Testing and Deployment Plan
<!-- Are there automated tests? How can a reviewer verify the change, if applicable? -->
<!-- Any issues forseen deploying this to production? -->


<!-- Don't forget to cc: any person or group who should be aware of this PR, and to assign a reviewer -->
