### PR TITLE
bugfix for BrozzlerWorker._needs_browsing

### DIFF
--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -447,7 +447,9 @@ class BrozzlerWorker:
                 if txn['response_headers'].get_content_type() in [
                         'text/html', 'application/xhtml+xml']:
                     return True
-        return False
+            return False
+        else:
+            return True
 
     def _already_fetched(self, page, brozzler_spy):
         if brozzler_spy:


### PR DESCRIPTION
I'm sorry but with my previous commit I introduced a bug in
``BrozzlerWorker._needs_browsing`` method.

More specifically, if the ``brozzler_spy`` param is False (this happens
when ``youtube_dl`` is disabled), ``_needs_browsing`` method returns
always ``False`` and this messes with ``brozzle_page`` workflow. The
browser is never visiting the page.

I'm fixing this here.

## Motivation
<!-- How does this code change improve the world? -->
<!-- Could be a reference to an issue/ticket tracker (like JIRA) if both author and reviewer have access permissions -->

## Description
<!-- What exactly does this do? Could be the git commit message -->

## Testing and Deployment Plan
<!-- Are there automated tests? How can a reviewer verify the change, if applicable? -->
<!-- Any issues forseen deploying this to production? -->


<!-- Don't forget to cc: any person or group who should be aware of this PR, and to assign a reviewer -->
