### PR TITLE
Log oulinks for all users of Browser.

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -452,6 +452,7 @@ class Browser:
                     outlinks = []
                 else:
                     outlinks = self.extract_outlinks()
+                    logging.info('outlinks: \n\t%s', '\n\t'.join(sorted(outlinks)))
                 if not skip_visit_hashtags:
                     self.visit_hashtags(page_url, hashtags, outlinks)
                 final_page_url = self.url()

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -189,9 +189,7 @@ def brozzle_page(argv=None):
     browser = brozzler.Browser(chrome_exe=args.chrome_exe)
     try:
         browser.start(proxy=args.proxy)
-        outlinks = worker.brozzle_page(
-                browser, site, page, on_screenshot=on_screenshot)
-        logging.info('outlinks: \n\t%s', '\n\t'.join(sorted(outlinks)))
+        worker.brozzle_page(browser, site, page, on_screenshot=on_screenshot)
     except brozzler.ReachedLimit as e:
         logging.error('reached limit %s', e)
     finally:


### PR DESCRIPTION
This makes is such that anyone using the Browser class (e.g. Umbra) will see the outlinks in their logs.