### PR TITLE
Add --disable-background-networking chromium flag

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -126,6 +126,7 @@ class Chrome:
                 '--remote-debugging-port=%s' % self.port,
                 '--use-mock-keychain', # mac thing
                 '--user-data-dir=%s' % self._chrome_user_data_dir,
+                '--disable-background-networking',
                 '--disable-web-sockets', '--disable-cache',
                 '--window-size=1100,900', '--no-default-browser-check',
                 '--disable-first-run-ui', '--no-first-run',


### PR DESCRIPTION
Chromium browser docs describe this as follows:
_Disable several subsystems which run network requests in the
background. This is for use when doing network performance testing to
avoid noise in the measurements._

Testing indicates that irrelevant HTTP requests like the following stop
with this improvement.
```
HEAD http://ugfgntuqva/ HTTP/1.1
```