### PR TITLE
Fix to delete tmpdir on Chrome.stop()

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -278,13 +278,13 @@ class Chrome:
                     'chrome pid %s reaped (status=%s) after killing with '
                     'SIGKILL', self.chrome_process.pid, status)
 
+        finally:
             try:
                 self._home_tmpdir.cleanup()
             except:
                 self.logger.error(
                         'exception deleting %s', self._home_tmpdir,
                         exc_info=True)
-        finally:
             self._out_reader_thread.join()
             self.chrome_process = None
 


### PR DESCRIPTION
The ``self._home_tmpdir.cleanup()`` cmd is not always executed when
stopping Chrome. As a result, a large number of ``/tmp/tmpXXX`` dirs are
created in production.

The reason is that ``Chrome.stop()`` execution can stop in the ``return``
statement in the following line:
https://github.com/internetarchive/brozzler/blob/master/brozzler/chrome.py#L268
and ``cleanup()`` does not run.

Moving the ``cleanup()`` in the ``finally`` part of the
``try/catch/finally`` block makes it run always in the end of
``Chrome.stop()`` and cleans up the tmp directory in any case.