### PR TITLE
Use wsaccess library to speed up websocket-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
             'reppy==0.3.4',
             'requests',
             'websocket-client!=0.39.0',
+            'wsaccel',
             'pillow==3.3.0',
             'urlcanon>=0.1.dev16',
             'doublethink>=0.2.0.dev81',


### PR DESCRIPTION
We use ``websocket-client`` to communicate with chromium-browser.
The ``websocket.send()`` method, which we use a lot, needs to do some data
encoding before sending it to chromium-browser.
``websocket-client`` tries to use ``wsaccel`` or ``numpy`` (C extensions) first
and if they are not available, it runs a python implementation of the data
encoding function that is terribly slow as they mention.

Here is their code that tries to use ``numpy`` or ``wsaccel``
https://github.com/websocket-client/websocket-client/blob/master/websocket/_abnf.py

Here is a latest issue talking about their performance issue:
https://github.com/websocket-client/websocket-client/issues/340

We don't use either of them. ``wsaccess`` is tiny and was supported
earlier by the library.
``numpy`` is huge and it is supported since 0.47 which is NOT available
in pip now (0.46 is available).

They say that ``numpy`` is faster but they seem the same to me in my test runs.

I suggest to just use ``wsaccel``. I've seen a small performance improvement.

We don't need to change anything in our code, just install this extra library.