### PR TITLE
Block google analytics URLs using new Network.setBlockedURLs API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - sudo pip install ansible==2.1.3.0
 install:
 - ansible-playbook --extra-vars="brozzler_pip_name=file://$TRAVIS_BUILD_DIR#egg=brozzler user=travis" --inventory-file=ansible/hosts-localhost ansible/playbook.yml
-- pip install $TRAVIS_BUILD_DIR 'warcprox==2.3' pytest
+- pip install $TRAVIS_BUILD_DIR 'warcprox>=2.4b1' pytest
 script:
 - DISPLAY=:1 py.test -v tests
 after_failure:

--- a/ansible/roles/pywb/tasks/main.yml
+++ b/ansible/roles/pywb/tasks/main.yml
@@ -5,6 +5,7 @@
   become: true
 - name: install pywb in virtualenv
   pip: name=pywb
+       version=0.33.2
        virtualenv={{venv_root}}/pywb-ve34
        virtualenv_python=python3.4
        extra_args='--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -320,8 +320,8 @@ class Browser:
             # disable google analytics
             self.send_to_chrome(
                 method='Network.setBlockedURLs',
-                params={'urls': ['http://www.google-analytics.com/analytics.js',
-                                 'https://www.google-analytics.com/analytics.js']
+                params={'urls': ['*google-analytics.com/analytics.js',
+                                 '*google-analytics.com/ga.js']}
                 )
 
     def stop(self):

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -288,10 +288,9 @@ class Browser:
         msg_id = next(self._command_id)
         kwargs['id'] = msg_id
         msg = json.dumps(kwargs)
-        #logging.log(
-        #        brozzler.TRACE if suppress_logging else logging.DEBUG,
-        #        'sending message to %s: %s', self.websock, msg)
-        # print(msg)
+        logging.log(
+                brozzler.TRACE if suppress_logging else logging.DEBUG,
+                'sending message to %s: %s', self.websock, msg)
         self.websock.send(msg)
         return msg_id
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def find_package_data(package):
 
 setuptools.setup(
         name='brozzler',
-        version='1.1b12.dev281',
+        version='1.1b12.dev282',
         description='Distributed web crawling with browsers',
         url='https://github.com/internetarchive/brozzler',
         author='Noah Levitt',

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,8 @@ setuptools.setup(
         extras_require={
             'dashboard': ['flask>=0.11', 'gunicorn'],
             'easy': [
-                'warcprox>=2.1b1.dev87',
-                'pywb',
+                'warcprox>=2.4b1.dev145',
+                'pywb<2',
                 'flask>=0.11',
                 'gunicorn'
             ],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def find_package_data(package):
 
 setuptools.setup(
         name='brozzler',
-        version='1.1b12.dev282',
+        version='1.1b12',
         description='Distributed web crawling with browsers',
         url='https://github.com/internetarchive/brozzler',
         author='Noah Levitt',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def find_package_data(package):
 
 setuptools.setup(
         name='brozzler',
-        version='1.1b12',
+        version='1.1b13.dev283',
         description='Distributed web crawling with browsers',
         url='https://github.com/internetarchive/brozzler',
         author='Noah Levitt',

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -661,11 +661,10 @@ def test_warcprox_outage_resiliency(httpd):
     opts = warcprox.Options()
     opts.address = '0.0.0.0'
     opts.port = 0
+    opts.rethinkdb_services_url = 'rethinkdb://localhost/brozzler/services'
 
-    warcprox1 = warcprox.controller.WarcproxController(
-            service_registry=svcreg, options=opts)
-    warcprox2 = warcprox.controller.WarcproxController(
-            service_registry=svcreg, options=opts)
+    warcprox1 = warcprox.controller.WarcproxController(opts)
+    warcprox2 = warcprox.controller.WarcproxController(opts)
     warcprox1_thread = threading.Thread(
             target=warcprox1.run_until_shutdown, name='warcprox1')
     warcprox2_thread = threading.Thread(


### PR DESCRIPTION
Use https://chromedevtools.github.io/devtools-protocol/tot/Network#method-setBlockedURLs instead of the JS debugger to block specific URLs. Its a new API available since chromium 64.

Block new and old versions of google analytics script (``ga.js``, ``analytics.js``), with or without ``www.`` prefix and `http` or `https` : ``(https?://(www.)?google-analytics.com/(analytics|ga).js`` 
Please note that the previous code only blocked ``https?://www.google-analytics.com/analytics.js``.
A lot of these URL variations are used in target sites.

Remove all JS debugger code as they are not needed any more.

This change requires Google Chrome or chromium-browser **64** to work.