### PR TITLE
WIP: claim sites to brozzle in batches to reduce contention over sites table

### DIFF
--- a/tests/test_frontier.py
+++ b/tests/test_frontier.py
@@ -826,30 +826,34 @@ def test_claim_site():
     rr.table('sites').delete().run() # clean slate
 
     with pytest.raises(brozzler.NothingToClaim):
-        claimed_site = frontier.claim_site(worker_id='test_claim_site')
+        claimed_site = frontier.claim_sites()
 
     site = brozzler.Site(rr, {'seed': 'http://example.org/'})
     brozzler.new_site(frontier, site)
 
-    claimed_site = frontier.claim_site(worker_id='test_claim_site')
+    claimed_sites = frontier.claim_sites()
+    assert len(claimed_sites) == 1
+    claimed_site = claimed_sites[0]
     assert claimed_site.id == site.id
     assert claimed_site.claimed
     assert claimed_site.last_claimed >= doublethink.utcnow() - datetime.timedelta(minutes=1)
     with pytest.raises(brozzler.NothingToClaim):
-        claimed_site = frontier.claim_site(worker_id='test_claim_site')
+        claimed_site = frontier.claim_sites()
 
     # site last_claimed less than 1 hour ago still not to be reclaimed
     claimed_site.last_claimed = doublethink.utcnow() - datetime.timedelta(minutes=55)
     claimed_site.save()
     with pytest.raises(brozzler.NothingToClaim):
-        claimed_site = frontier.claim_site(worker_id='test_claim_site')
+        claimed_site = frontier.claim_sites()
 
     # site last_claimed more than 1 hour ago can be reclaimed
     site = claimed_site
     claimed_site = None
     site.last_claimed = doublethink.utcnow() - datetime.timedelta(minutes=65)
     site.save()
-    claimed_site = frontier.claim_site(worker_id='test_claim_site')
+    claimed_sites = frontier.claim_sites()
+    assert len(claimed_sites) == 1
+    claimed_site = claimed_sites[0]
     assert claimed_site.id == site.id
 
     # clean up


### PR DESCRIPTION
## Motivation
Archive-it brozzler cluster is not keeping all available browsers busy even if there are more active sites than available browsers. It appears this is because claiming a site to brozzle takes too long sometimes, due to contention over the table.

## Description
Claim sites to brozzle in batches to reduce contention over sites table. Workers claim up to `(available_browsers + 1) // 2` at a time.

