### PR TITLE
Add chromium CLI flags to improve capture performance

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -156,11 +156,16 @@ class Chrome:
                 '--use-mock-keychain', # mac thing
                 '--user-data-dir=%s' % self._chrome_user_data_dir,
                 '--disable-background-networking',
+                '--disable-renderer-backgrounding', '--disable-hang-monitor',
+                '--disable-background-timer-throttling', '--mute-audio',
                 '--disable-web-sockets', '--disable-cache',
                 '--window-size=1100,900', '--no-default-browser-check',
                 '--disable-first-run-ui', '--no-first-run',
                 '--homepage=about:blank', '--disable-direct-npapi-requests',
                 '--disable-web-security', '--disable-notifications',
+                '--disable-client-side-phishing-detection',
+                '--safebrowsing-disable-auto-update',
+                '--safebrowsing-disable-download-protection',
                 '--disable-extensions', '--disable-save-password-bubble']
         if self.ignore_cert_errors:
             chrome_args.append('--ignore-certificate-errors')

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -163,9 +163,6 @@ class Chrome:
                 '--disable-first-run-ui', '--no-first-run',
                 '--homepage=about:blank', '--disable-direct-npapi-requests',
                 '--disable-web-security', '--disable-notifications',
-                '--disable-client-side-phishing-detection',
-                '--safebrowsing-disable-auto-update',
-                '--safebrowsing-disable-download-protection',
                 '--disable-extensions', '--disable-save-password-bubble']
         if self.ignore_cert_errors:
             chrome_args.append('--ignore-certificate-errors')


### PR DESCRIPTION
``--disable-background-timer-throttling`` and ``--disable-renderer-backgrounding``:
karma JS test runner uses these to improve chrome performance
https://github.com/karma-runner/karma-chrome-launcher/issues/123

``--disable-hang-monitor``: Suppresses hang monitor dialogs in renderer
processes. This may allow slow unload handlers on a page to prevent the
tab from closing, but the Task Manager can be used to terminate the
offending process in this case.

``--mute-audio``: obvious.

The following are part of google safe browsing features:
``--disable-client-side-phishing-detection``
``--safebrowsing-disable-auto-update``
``--safebrowsing-disable-download-protection``

Good reference with all chromium cli opts: https://peter.sh/experiments/chromium-command-line-switches/