### PR TITLE
Browser.configure_browser optimisation

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -520,15 +520,11 @@ class Browser:
     def configure_browser(self, extra_headers=None, user_agent=None):
         headers = extra_headers or {}
         headers['Accept-Encoding'] = 'gzip'  # avoid encodings br, sdch
-        self.websock_thread.expect_result(self._command_id.peek())
-        msg_id = self.send_to_chrome(
+        self.send_to_chrome(
                 method='Network.setExtraHTTPHeaders',
                 params={'headers': headers})
-        self._wait_for(
-                lambda: self.websock_thread.received_result(msg_id),
-                timeout=10)
         if user_agent:
-            msg_id = self.send_to_chrome(
+            self.send_to_chrome(
                     method='Network.setUserAgentOverride',
                     params={'userAgent': user_agent})
 


### PR DESCRIPTION
We use `Network.setExtraHTTPHeaders` and then we use `self._wait_for` to wait
for the result.
This is redundant as we don't do anything with the result, we shouldn't
wait here.

Also, in the same method we use `Network.setUserAgentOverride` and we
don't wait for that. I'm saying this to indicate that waiting isn't
necessary after setting browser options like these.

This change improves any capture speed by 0.5 sec in my benchmarks.
(Its because the `_wait_for` loop has a `sleep(0.5)`).