### PR TITLE
Send more compact JSON to browser

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -228,7 +228,7 @@ class WebsockReceiverThread(threading.Thread):
         self.websock.send(
                 json.dumps(dict(
                     id=0, method='Page.handleJavaScriptDialog',
-                    params={'accept': accept})), separators=',:')
+                    params={'accept': accept}), separators=',:'))
 
     def _handle_message(self, websock, json_message):
         message = json.loads(json_message)

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -228,7 +228,7 @@ class WebsockReceiverThread(threading.Thread):
         self.websock.send(
                 json.dumps(dict(
                     id=0, method='Page.handleJavaScriptDialog',
-                    params={'accept': accept})))
+                    params={'accept': accept})), separators=',:')
 
     def _handle_message(self, websock, json_message):
         message = json.loads(json_message)
@@ -314,7 +314,7 @@ class Browser:
     def send_to_chrome(self, suppress_logging=False, **kwargs):
         msg_id = next(self._command_id)
         kwargs['id'] = msg_id
-        msg = json.dumps(kwargs)
+        msg = json.dumps(kwargs, separators=',:')
         logging.log(
                 brozzler.TRACE if suppress_logging else logging.DEBUG,
                 'sending message to %s: %s', self.websock, msg)


### PR DESCRIPTION
Use JSON separators without spaces to reduce json size.
Its already used elsewhere in Brozzler but not here.