### PR TITLE
Disable Jinja2 template auto_reload for higher performance

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -258,7 +258,7 @@ def jinja2_environment(behaviors_dir=None):
                                                            'js-templates'))
         else:
             _loader=jinja2.PackageLoader('brozzler', 'js-templates')
-        _jinja2_env = jinja2.Environment(loader=_loader)
+        _jinja2_env = jinja2.Environment(loader=_loader, auto_reload=False)
         _jinja2_env.filters['json'] = json.dumps
     return _jinja2_env
 


### PR DESCRIPTION
Every time we run a JS behavior, we load a Jinja2 template. By default, Jinja2 has option `auto_reload=True`. This mean that every time a template is requested the loader checks if the source file changed and if yes, it will reload the template. For higher performance it’s possible to disable that.

Also note that Jinja caches 400 templates by default.

Ref: http://jinja.pocoo.org/docs/2.10/api/

In Brozzler, we don't make changes to JS templates while the system is running. So, there is no point in having `auto_reload=True`.
