### PR TITLE
Disable chromium sandbox to improve performance

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -155,6 +155,7 @@ class Chrome:
                 '--remote-debugging-port=%s' % self.port,
                 '--use-mock-keychain', # mac thing
                 '--user-data-dir=%s' % self._chrome_user_data_dir,
+                '--no-sandbox',
                 '--disable-background-networking',
                 '--disable-renderer-backgrounding', '--disable-hang-monitor',
                 '--disable-background-timer-throttling', '--mute-audio',


### PR DESCRIPTION
Use `--disable-sandbox` to disable chromium sandboxed processes
(restrictive environment for improved security). We don't need this in
the Brozzler use case and the performance is improved without it.

Info on chromium sandbox:
https://chromium.googlesource.com/chromium/src/+/master/docs/design/sandbox.md

The idea came up to me after seeing:
https://github.com/kennethreitz/requests-html/blob/master/requests_html.py#L467