### PR TITLE
Use single process model for chromium-browser

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -158,7 +158,7 @@ class Chrome:
                 '--disable-background-networking',
                 '--disable-renderer-backgrounding', '--disable-hang-monitor',
                 '--disable-background-timer-throttling', '--mute-audio',
-                '--disable-web-sockets', '--disable-cache',
+                '--disable-web-sockets', '--disable-cache', '--single-process',
                 '--window-size=1100,900', '--no-default-browser-check',
                 '--disable-first-run-ui', '--no-first-run',
                 '--homepage=about:blank', '--disable-direct-npapi-requests',


### PR DESCRIPTION
By default chromium creates multiple renderer processes (each running
multiple threads) for each instance of a site the user visits. What we
see from `ps auxcf` output is the following:
```
\_ chromium-browse
  \_ chromium-browse
  |   \_ chromium-browse
  |       \_ chromium-browse
  |       \_ chromium-browse
  |       \_ chromium-browse
```

Using the `--single-process` option, we run all renderers in the same
process, saving the overhead of running multiple processes. `ps auxcf`
output is the following:

```
\_ chromium-browse
  \_ chromium-browse
    \_ chromium-browse
```

Performance is improved a bit and I guess that using this in large scale
Brozzler deployments will have even better performance effects.

The potential problem of `--single-process` is stability (if a renderer
crashes, the whole browser also crashes) but since we use very short-lived
instances of chromium, we don't worry about this.

Details on chromium process models:
https://www.chromium.org/developers/design-documents/process-models
