### PR TITLE
reimplement max_claimed_sites

### DIFF
--- a/brozzler/model.py
+++ b/brozzler/model.py
@@ -86,7 +86,6 @@ def new_job(frontier, job_conf):
     sites = []
     for seed_conf in job_conf["seeds"]:
         merged_conf = merge(seed_conf, job_conf)
-        merged_conf.pop("max_claimed_sites", None)
         merged_conf.pop("seeds")
         merged_conf["job_id"] = job.id
         merged_conf["seed"] = merged_conf.pop("url")


### PR DESCRIPTION
Other approach was too slow and caused db contention.
New approach avoids (slow) rethinkdb join by max_claimed_sites job
parameter to each of the job's sites. Uses rethinkdb fold() to count
claimed sites and enforce max_claimed_sites within a single query.

## Motivation
<!-- How does this code change improve the world? -->
<!-- Could be a reference to an issue/ticket tracker (like JIRA) if both author and reviewer have access permissions -->

## Description
<!-- What exactly does this do? Could be the git commit message -->

## Testing and Deployment Plan
<!-- Are there automated tests? How can a reviewer verify the change, if applicable? -->
<!-- Any issues forseen deploying this to production? -->


<!-- Don't forget to cc: any person or group who should be aware of this PR, and to assign a reviewer -->
