### PR TITLE
treat any error fetching robots.txt as "allow all"

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -769,7 +769,7 @@ def test_time_limit(httpd):
     rr = doublethink.Rethinker('localhost', db='brozzler')
     frontier = brozzler.RethinkDbFrontier(rr)
 
-    # create a new job with three sites that could be crawled forever
+    # create a new job with one seed that could be crawled forever
     job_conf = {'seeds': [{
         'url': 'http://localhost:%s/infinite/foo/' % httpd.server_port,
         'time_limit': 20}]}
@@ -789,6 +789,10 @@ def test_time_limit(httpd):
     assert sites[0].status == 'FINISHED_TIME_LIMIT'
 
     # all sites finished so job should be finished too
+    start = time.time()
     job.refresh()
+    while not job.status == 'FINISHED' and time.time() - start < 10:
+        time.sleep(0.5)
+        job.refresh()
     assert job.status == 'FINISHED'
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -74,9 +74,9 @@ def test_robots_http_statuses():
             500, 501, 502, 503, 504, 505):
         class Handler(http.server.BaseHTTPRequestHandler):
             def do_GET(self):
-                response = (b'HTTP/1.1 %s Meaningless message\r\n'
-                          + b'Content-length: 0\r\n'
-                          + b'\r\n') % status
+                response = (('HTTP/1.1 %s Meaningless message\r\n'
+                          + 'Content-length: 0\r\n'
+                          + '\r\n') % status).encode('utf-8')
                 self.connection.sendall(response)
                 # self.send_response(status)
                 # self.end_headers()
@@ -93,7 +93,7 @@ def test_robots_http_statuses():
             httpd.server_close()
             httpd_thread.join()
 
-def test_robots_empty_respone():
+def test_robots_empty_response():
     class Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             self.connection.shutdown(socket.SHUT_RDWR)
@@ -140,6 +140,12 @@ def test_robots_socket_timeout():
 def test_robots_dns_failure():
     # .invalid. is guaranteed nonexistent per rfc 6761
     url = 'http://whatever.invalid./'
+    site = brozzler.Site(None, {'seed': url})
+    assert brozzler.is_permitted_by_robots(site, url)
+
+def test_robots_connection_failure():
+    # .invalid. is guaranteed nonexistent per rfc 6761
+    url = 'http://localhost:4/' # nobody listens on port 4
     site = brozzler.Site(None, {'seed': url})
     assert brozzler.is_permitted_by_robots(site, url)
 


### PR DESCRIPTION
Policy is similar to heritrix's (changed fairly recently).
https://github.com/internetarchive/heritrix3/pull/187/files
Includes tests. 