### PR TITLE
brozzler-purge - purge crawl state from rethinkdb

### DIFF
--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -592,15 +592,16 @@ def brozzler_purge(argv=None):
     argv = argv or sys.argv
     arg_parser = argparse.ArgumentParser(
             prog=os.path.basename(argv[0]),
+            description='brozzler-purge - purge crawl state from rethinkdb',
             formatter_class=BetterArgumentDefaultsHelpFormatter)
     group = arg_parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
             '--job', dest='job', metavar='JOB_ID', help=(
-                'delete crawl state from rethinkdb for a job, including all '
+                'purge crawl state from rethinkdb for a job, including all '
                 'sites and pages'))
     group.add_argument(
             '--site', dest='site', metavar='SITE_ID', help=(
-                'delete crawl state from rethinkdb for a site, including all '
+                'purge crawl state from rethinkdb for a site, including all '
                 'pages'))
     arg_parser.add_argument(
             '--force', dest='force', action='store_true', help=(

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
                 'brozzler-list-sites=brozzler.cli:brozzler_list_sites',
                 'brozzler-list-pages=brozzler.cli:brozzler_list_pages',
                 'brozzler-stop-crawl=brozzler.cli:brozzler_stop_crawl',
+                'brozzler-purge=brozzler.cli:brozzler_purge',
                 'brozzler-dashboard=brozzler.dashboard:main',
                 'brozzler-easy=brozzler.easy:main',
                 'brozzler-wayback=brozzler.pywb:main',


### PR DESCRIPTION
Useful for clearing cruft from rethinkdb, especially the `pages` table, which can get huge.