### PR TITLE
change time limit enforcement

### DIFF
--- a/brozzler/frontier.py
+++ b/brozzler/frontier.py
@@ -152,17 +152,15 @@ class RethinkDbFrontier:
         else:
             raise brozzler.NothingToClaim
 
-    def enforce_time_limit(self, site, session_time=0):
+    def enforce_time_limit(self, site):
         '''
         Raises `brozzler.ReachedTimeLimit` if appropriate.
         '''
-        if (site.time_limit
-                and site.time_limit > 0
-                and (site.active_brozzling_time or 0) + session_time > site.time_limit):
+        if (site.time_limit and site.time_limit > 0
+                and site.elapsed() > site.time_limit):
             self.logger.debug(
                     "site FINISHED_TIME_LIMIT! time_limit=%s "
-                    "active_brozzling_time=%s %s", site.time_limit,
-                    site.active_brozzling_time, site)
+                    "elapsed=%s %s", site.time_limit, site.elapsed(), site)
             raise brozzler.ReachedTimeLimit
 
     def claim_page(self, site, worker_id):

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -345,7 +345,7 @@ class BrozzlerWorker:
                     self._proxy_for(site), site)
             while time.time() - start < self.SITE_SESSION_MINUTES * 60:
                 site.refresh()
-                self._frontier.enforce_time_limit(site, time.time() - start)
+                self._frontier.enforce_time_limit(site)
                 self._frontier.honor_stop_request(site)
                 page = self._frontier.claim_page(site, "%s:%s" % (
                     socket.gethostname(), browser.chrome.port))


### PR DESCRIPTION
enforce time limit based on all the time that a site was in active
rotation, including time it spent waiting for its turn to be brozzled;
this undoes the change from b9640b8a30c934, because now it seems that
was the wrong decision (brozzler jobs with many seeds and low
max_claimed_sites hanging around forever)