### PR TITLE
AITFIVE-1529 http auth and test

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -58,6 +58,28 @@ class ReachedLimit(Exception):
     def __str__(self):
         return self.__repr__()
 
+class PageInterstitialShown(Exception):
+    def __init__(self, http_error=None, warcprox_meta=None, http_payload=None):
+        import json
+        if http_error:
+            if "warcprox-meta" in http_error.headers:
+                self.warcprox_meta = json.loads(
+                        http_error.headers["warcprox-meta"])
+            else:
+                self.warcprox_meta = None
+            self.http_payload = http_error.read()
+        elif warcprox_meta:
+            self.warcprox_meta = warcprox_meta
+            self.http_payload = http_payload
+
+    def __repr__(self):
+        return "PageInterstitialShown(warcprox_meta=%r,http_payload=%r)" % (
+                self.warcprox_meta if hasattr(self, 'warcprox_meta') else None,
+                self.http_payload if hasattr(self, 'http_payload') else None)
+
+    def __str__(self):
+        return self.__repr__()
+
 # monkey-patch log levels TRACE and NOTICE
 logging.TRACE = (logging.NOTSET + logging.DEBUG) // 2
 def _logger_trace(self, msg, *args, **kwargs):

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -30,6 +30,9 @@ class NothingToClaim(Exception):
 class CrawlStopped(Exception):
     pass
 
+class PageInterstitialShown(Exception):
+    pass
+
 class ProxyError(Exception):
     pass
 
@@ -52,28 +55,6 @@ class ReachedLimit(Exception):
 
     def __repr__(self):
         return "ReachedLimit(warcprox_meta=%r,http_payload=%r)" % (
-                self.warcprox_meta if hasattr(self, 'warcprox_meta') else None,
-                self.http_payload if hasattr(self, 'http_payload') else None)
-
-    def __str__(self):
-        return self.__repr__()
-
-class PageInterstitialShown(Exception):
-    def __init__(self, http_error=None, warcprox_meta=None, http_payload=None):
-        import json
-        if http_error:
-            if "warcprox-meta" in http_error.headers:
-                self.warcprox_meta = json.loads(
-                        http_error.headers["warcprox-meta"])
-            else:
-                self.warcprox_meta = None
-            self.http_payload = http_error.read()
-        elif warcprox_meta:
-            self.warcprox_meta = warcprox_meta
-            self.http_payload = http_payload
-
-    def __repr__(self):
-        return "PageInterstitialShown(warcprox_meta=%r,http_payload=%r)" % (
                 self.warcprox_meta if hasattr(self, 'warcprox_meta') else None,
                 self.http_payload if hasattr(self, 'http_payload') else None)
 

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -243,12 +243,10 @@ class WebsockReceiverThread(threading.Thread):
             elif message['method'] == 'Page.interstitialShown':
                 # AITFIVE-1529: handle http auth
                 # we should kill the browser when we receive Page.interstitialShown and
-                # consider the page finished, until this is fixed: https://bugs.chromium.org/p/chromium/issues/detail?id=764505
-                self.page_interstitial_shown = brozzler.PageInterstitialShown(
-                        warcprox_meta=None)
-                self.logger.info('Page.interstialShown (likely http auth request) %s', self.page_interstitial_shown)
-                brozzler.thread_raise(
-                        self.calling_thread, brozzler.PageInterstitialShown)
+                # consider the page finished, until this is fixed:
+                # https://bugs.chromium.org/p/chromium/issues/detail?id=764505
+                self.logger.info('Page.interstialShown (likely unsupported http auth request)')
+                brozzler.thread_raise(self.calling_thread, brozzler.PageInterstitialShown)
             elif message['method'] == 'Inspector.targetCrashed':
                 self.logger.error(
                         '''chrome tab went "aw snap" or "he's dead jim"!''')

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -241,10 +241,11 @@ class WebsockReceiverThread(threading.Thread):
                 if self.on_request:
                     self.on_request(message)
             elif message['method'] == 'Page.interstitialShown':
-                # for AITFIVE-1529: handle http auth
-                # for now, we should consider killing the browser when we receive Page.interstitialShown and
-                # consider the page finished—-first we should figure out when else that event might happen
-                self.logger.info('Page.interstitialShown received')
+                # AITFIVE-1529: handle http auth
+                # we should kill the browser when we receive Page.interstitialShown and
+                # consider the page finished, until this is fixed: https://bugs.chromium.org/p/chromium/issues/detail?id=764505
+                self.logger.info('Page.interstitialShown received: likely http auth request, currently unsupported')
+                brozzler.thread_raise(self.calling_thread, BrowsingException)
             elif message['method'] == 'Inspector.targetCrashed':
                 self.logger.error(
                         '''chrome tab went "aw snap" or "he's dead jim"!''')

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -244,8 +244,11 @@ class WebsockReceiverThread(threading.Thread):
                 # AITFIVE-1529: handle http auth
                 # we should kill the browser when we receive Page.interstitialShown and
                 # consider the page finished, until this is fixed: https://bugs.chromium.org/p/chromium/issues/detail?id=764505
-                self.logger.info('Page.interstitialShown received: likely http auth request, currently unsupported')
-                brozzler.thread_raise(self.calling_thread, BrowsingException)
+                self.page_interstitial_shown = brozzler.PageInterstitialShown(
+                        warcprox_meta=None)
+                self.logger.info('Page.interstialShown (likely http auth request) %s', self.page_interstitial_shown)
+                brozzler.thread_raise(
+                        self.calling_thread, brozzler.PageInterstitialShown)
             elif message['method'] == 'Inspector.targetCrashed':
                 self.logger.error(
                         '''chrome tab went "aw snap" or "he's dead jim"!''')

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -198,6 +198,8 @@ def brozzle_page(argv=None):
         logging.info('outlinks: \n\t%s', '\n\t'.join(sorted(outlinks)))
     except brozzler.ReachedLimit as e:
         logging.error('reached limit %s', e)
+    except brozzler.PageInterstitialShown as e:
+        logging.error('page interstitial shown %s', e)
     finally:
         browser.stop()
 

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -210,23 +210,12 @@ class BrozzlerWorker:
 
         if self._needs_browsing(page, ydl_fetches):
             self.logger.info('needs browsing: %s', page)
-<<<<<<< HEAD
-            browser_outlinks = self._browse_page(
-                    browser, site, page, on_screenshot, on_request)
-            outlinks.update(browser_outlinks)
-=======
             try:
-                outlinks = self._browse_page(browser, site, page, on_screenshot,
-                                            on_request)
+                browser_outlinks = self._browse_page(
+                    browser, site, page, on_screenshot, on_request)
+                outlinks.update(browser_outlinks)
             except brozzler.PageInterstitialShown:
-                outlinks = []
                 self.logger.info('page interstitial shown (http auth): %s', page)
-<<<<<<< HEAD
-                return []
->>>>>>> d9f7997... except log and return []
-=======
-            return outlinks
->>>>>>> 1054d2d... return outlinks = []
         else:
             if not self._already_fetched(page, ydl_fetches):
                 self.logger.info('needs fetch: %s', page)

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -192,8 +192,6 @@ class BrozzlerWorker:
                 ydl_fetches, outlinks = ydl.do_youtube_dl(self, site, page)
             except brozzler.ReachedLimit as e:
                 raise
-            except brozzler.PageInterstitialShown as e:
-                raise
             except brozzler.ShutdownRequested:
                 raise
             except brozzler.ProxyError:
@@ -373,14 +371,14 @@ class BrozzlerWorker:
             self.logger.info("shutdown requested")
         except brozzler.NothingToClaim:
             self.logger.info("no pages left for site %s", site)
-        except brozzler.PageInterstitialShown:
-            pass
         except brozzler.ReachedLimit as e:
             self._frontier.reached_limit(site, e)
         except brozzler.ReachedTimeLimit as e:
             self._frontier.finished(site, "FINISHED_TIME_LIMIT")
         except brozzler.CrawlStopped:
             self._frontier.finished(site, "FINISHED_STOP_REQUESTED")
+        except brozzler.PageInterstitialShown:
+            self.logger.info("{} shut down after unsupported http auth request".format(browser))
         # except brozzler.browser.BrowsingAborted:
         #     self.logger.info("{} shut down".format(browser))
         except brozzler.ProxyError as e:

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -218,11 +218,15 @@ class BrozzlerWorker:
             try:
                 outlinks = self._browse_page(browser, site, page, on_screenshot,
                                             on_request)
-                return outlinks
             except brozzler.PageInterstitialShown:
+                outlinks = []
                 self.logger.info('page interstitial shown (http auth): %s', page)
+<<<<<<< HEAD
                 return []
 >>>>>>> d9f7997... except log and return []
+=======
+            return outlinks
+>>>>>>> 1054d2d... return outlinks = []
         else:
             if not self._already_fetched(page, ydl_fetches):
                 self.logger.info('needs fetch: %s', page)

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -210,9 +210,19 @@ class BrozzlerWorker:
 
         if self._needs_browsing(page, ydl_fetches):
             self.logger.info('needs browsing: %s', page)
+<<<<<<< HEAD
             browser_outlinks = self._browse_page(
                     browser, site, page, on_screenshot, on_request)
             outlinks.update(browser_outlinks)
+=======
+            try:
+                outlinks = self._browse_page(browser, site, page, on_screenshot,
+                                            on_request)
+                return outlinks
+            except brozzler.PageInterstitialShown:
+                self.logger.info('page interstitial shown (http auth): %s', page)
+                return []
+>>>>>>> d9f7997... except log and return []
         else:
             if not self._already_fetched(page, ydl_fetches):
                 self.logger.info('needs fetch: %s', page)
@@ -377,8 +387,6 @@ class BrozzlerWorker:
             self._frontier.finished(site, "FINISHED_TIME_LIMIT")
         except brozzler.CrawlStopped:
             self._frontier.finished(site, "FINISHED_STOP_REQUESTED")
-        except brozzler.PageInterstitialShown:
-            self.logger.info("{} shut down after unsupported http auth request".format(browser))
         # except brozzler.browser.BrowsingAborted:
         #     self.logger.info("{} shut down".format(browser))
         except brozzler.ProxyError as e:

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -192,6 +192,8 @@ class BrozzlerWorker:
                 ydl_fetches, outlinks = ydl.do_youtube_dl(self, site, page)
             except brozzler.ReachedLimit as e:
                 raise
+            except brozzler.PageInterstitialShown as e:
+                raise
             except brozzler.ShutdownRequested:
                 raise
             except brozzler.ProxyError:
@@ -371,6 +373,8 @@ class BrozzlerWorker:
             self.logger.info("shutdown requested")
         except brozzler.NothingToClaim:
             self.logger.info("no pages left for site %s", site)
+        except brozzler.PageInterstitialShown:
+            pass
         except brozzler.ReachedLimit as e:
             self._frontier.reached_limit(site, e)
         except brozzler.ReachedTimeLimit as e:

--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -111,6 +111,12 @@ def test_aw_snap_hes_dead_jim():
         with pytest.raises(brozzler.BrowsingException):
             browser.browse_page('chrome://crash')
 
+def test_page_interstitial_exception():
+    chrome_exe = brozzler.suggest_default_chrome_exe()
+    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+        with pytest.raises(brozzler.PageInterstitialShown):
+            browser.browse_page('https://monitor.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=38.wbgrp')
+
 def test_on_response(httpd):
     response_urls = []
     def on_response(msg):

--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -63,8 +63,8 @@ def httpd(request):
                 self.end_headers()
                 self.wfile.write(payload)
             elif self.path == '/401':
-                self.send_response(401, 'Unauthorized')
-                self.send_header('Connection', 'close')
+                self.send_response(401, 'Authenticate')
+                self.send_header('WWW-Authenticate', 'Basic realm=JSL')
                 self.end_headers()
             else:
                 super().do_GET()

--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -62,6 +62,10 @@ def httpd(request):
                 self.send_header('Content-Length', len(payload))
                 self.end_headers()
                 self.wfile.write(payload)
+            elif self.path == '/401':
+                self.send_response(401, 'Unauthorized')
+                self.send_header('Connection', 'close')
+                self.end_headers()
             else:
                 super().do_GET()
 
@@ -113,9 +117,10 @@ def test_aw_snap_hes_dead_jim():
 
 def test_page_interstitial_exception():
     chrome_exe = brozzler.suggest_default_chrome_exe()
+    url = 'http://localhost:%s/401' % httpd.server_port
     with brozzler.Browser(chrome_exe=chrome_exe) as browser:
         with pytest.raises(brozzler.PageInterstitialShown):
-            browser.browse_page('https://monitor.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=38.wbgrp')
+            browser.browse_page(url)
 
 def test_on_response(httpd):
     response_urls = []

--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -128,6 +128,13 @@ def test_aw_snap_hes_dead_jim():
         with pytest.raises(brozzler.BrowsingException):
             browser.browse_page('chrome://crash')
 
+def test_page_interstitial_exception_live():
+    url = 'https://monitor.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=38.wbgrp'
+    chrome_exe = brozzler.suggest_default_chrome_exe()
+    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+        with pytest.raises(brozzler.PageInterstitialShown):
+            browser.browse_page(url)
+
 def test_page_interstitial_exception(httpd):
     chrome_exe = brozzler.suggest_default_chrome_exe()
     url = 'http://localhost:%s/401' % httpd.server_port


### PR DESCRIPTION
## Motivation
AITFIVE-1529

## Description
brozzler currently times out on pages requiring http auth—instead, we'd rather stop the browser and call the page finished

## Testing and Deployment Plan
test added
