### PR TITLE
no skipIframes for umbraBehavior

### DIFF
--- a/brozzler/behaviors.yaml
+++ b/brozzler/behaviors.yaml
@@ -25,8 +25,6 @@
   url_regex: '^https?://(?:www\.)?instagram\.com/.*$'
   behavior_js_template: umbraBehavior.js.j2
   default_parameters:
-    interval: 500
-    skip_iframes: true
     actions:
       - selector: button.coreSpriteDismissLarge
       - selector: 'a>.eLAPa>.KL4Bh'

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -26,11 +26,6 @@ class UmbraBehavior {
         this.idleSince = null;
         this.intervalId = null;
         this.intervalTimeMs = {{interval or 300}};
-        {% if skip_iframes %}
-        this.skipIframes = true;
-        {% else %}
-        this.skipIframes = false;
-        {% endif %}
         this.index = 0;
     }
 
@@ -48,17 +43,15 @@ class UmbraBehavior {
 
         var documents = [];
         documents[0] = document;
-        if (!(this.skipIframes)) {
-            var iframes = document.querySelectorAll("iframe");
-            var iframesLength = iframes.length;
-            for (var i = 0; i < iframesLength; i++) {
-                try {
-                    documents.push(iframes[i].contentWindow.document);
-                } catch (e) {
-                    // it'd be too much logging because this is common:
-                    // SecurityError: Blocked a frame with origin "..." from accessing a cross-origin frame
-                    // console.log("exception looking at iframe" + iframes[i] + ": " + e);
-                }
+        var iframes = document.querySelectorAll("iframe");
+        var iframesLength = iframes.length;
+        for (var i = 0; i < iframesLength; i++) {
+            try {
+                documents.push(iframes[i].contentWindow.document);
+            } catch (e) {
+                // it'd be too much logging because this is common:
+                // SecurityError: Blocked a frame with origin "..." from accessing a cross-origin frame
+                // console.log("exception looking at iframe" + iframes[i] + ": " + e);
             }
         }
         var documentsLength = documents.length;


### PR DESCRIPTION
the new try/catch block wrapping iframe additions to the documents var fixes the issue the skipIframes param addressed. Let's keep things simple and remove skipIframes.