### PR TITLE
Add disk cache options to Chrome

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -151,8 +151,7 @@ class Chrome:
             disk_cache_dir: use directory for disk cache. The default location
                 is inside `self._home_tmpdir` (default None).
             disk_cache_size: Forces the maximum disk space to be used by the disk
-                cache, in bytes. Used only when `cache` is a disk path.
-                (default None)
+                cache, in bytes. (default None)
         Returns:
             websocket url to chrome window with about:blank loaded
         '''

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -62,8 +62,7 @@ def check_version(chrome_exe):
 class Chrome:
     logger = logging.getLogger(__module__ + '.' + __qualname__)
 
-    def __init__(self, chrome_exe, port=9222, ignore_cert_errors=False,
-                 disk_cache_dir=None, disk_cache_size=None):
+    def __init__(self, chrome_exe, port=9222, ignore_cert_errors=False):
         '''
         Initializes instance of this class.
 
@@ -80,8 +79,6 @@ class Chrome:
         self.ignore_cert_errors = ignore_cert_errors
         self._shutdown = threading.Event()
         self.chrome_process = None
-        self.disk_cache_dir = disk_cache_dir
-        self.disk_cache_size = disk_cache_size
 
     def __enter__(self):
         '''
@@ -161,10 +158,6 @@ class Chrome:
             self._home_tmpdir.name, 'chrome-user-data')
         if cookie_db:
             self._init_cookie_db(cookie_db)
-        if disk_cache_dir:
-            self.disk_cache_dir = disk_cache_dir
-        if disk_cache_size:
-            self.disk_cache_size = disk_cache_size
         self._shutdown.clear()
 
         new_env = os.environ.copy()
@@ -184,10 +177,10 @@ class Chrome:
                 '--disable-web-security', '--disable-notifications',
                 '--disable-extensions', '--disable-save-password-bubble']
 
-        if self.disk_cache_dir:
-            chrome_args.append('--disk-cache-dir=%s' % self.disk_cache_dir)
-        if self.disk_cache_size:
-            chrome_args.append('--disk-cache-size=%s' % self.disk_cache_size)
+        if disk_cache_dir:
+            chrome_args.append('--disk-cache-dir=%s' % disk_cache_dir)
+        if disk_cache_size:
+            chrome_args.append('--disk-cache-size=%s' % disk_cache_size)
         if self.ignore_cert_errors:
             chrome_args.append('--ignore-certificate-errors')
         if proxy:


### PR DESCRIPTION
Add `Chrome` options `disk_cache_dir` and `disk_cache_size` which add chromium
options `--disk-cache-dir=<DIR>` and `--disk-cache-size=N` (bytes).