### PR TITLE
Add headless chrome option

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -62,7 +62,8 @@ def check_version(chrome_exe):
 class Chrome:
     logger = logging.getLogger(__module__ + '.' + __qualname__)
 
-    def __init__(self, chrome_exe, port=9222, ignore_cert_errors=False):
+    def __init__(self, chrome_exe, port=9222, headless=False,
+                 ignore_cert_errors=False):
         '''
         Initializes instance of this class.
 
@@ -71,11 +72,13 @@ class Chrome:
         Args:
             chrome_exe: filesystem path to chrome/chromium executable
             port: chrome debugging protocol port (default 9222)
+            headless: run in headless mode, without X windows (default: False)
             ignore_cert_errors: configure chrome to accept all certs (default
                 False)
         '''
         self.port = port
         self.chrome_exe = chrome_exe
+        self.headless = headless
         self.ignore_cert_errors = ignore_cert_errors
         self._shutdown = threading.Event()
         self.chrome_process = None
@@ -134,13 +137,12 @@ class Chrome:
                     cookie_location, exc_info=True)
         return cookie_db
 
-    def start(self, headless=False, proxy=None, cookie_db=None,
+    def start(self, proxy=None, cookie_db=None,
               disk_cache_dir=None, disk_cache_size=None):
         '''
         Starts chrome/chromium process.
 
         Args:
-            headless: run in headless mode, without X windows (default: False)
             proxy: http proxy 'host:port' (default None)
             cookie_db: raw bytes of chrome/chromium sqlite3 cookies database,
                 which, if supplied, will be written to
@@ -177,7 +179,7 @@ class Chrome:
                 '--homepage=about:blank', '--disable-direct-npapi-requests',
                 '--disable-web-security', '--disable-notifications',
                 '--disable-extensions', '--disable-save-password-bubble']
-        if headless:
+        if self.headless:
             chrome_args.append('--headless')
         if disk_cache_dir:
             chrome_args.append('--disk-cache-dir=%s' % disk_cache_dir)

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -134,12 +134,13 @@ class Chrome:
                     cookie_location, exc_info=True)
         return cookie_db
 
-    def start(self, proxy=None, cookie_db=None, disk_cache_dir=None,
-              disk_cache_size=None):
+    def start(self, headless=False, proxy=None, cookie_db=None,
+              disk_cache_dir=None, disk_cache_size=None):
         '''
         Starts chrome/chromium process.
 
         Args:
+            headless: run in headless mode, without X windows (default: False)
             proxy: http proxy 'host:port' (default None)
             cookie_db: raw bytes of chrome/chromium sqlite3 cookies database,
                 which, if supplied, will be written to
@@ -176,7 +177,8 @@ class Chrome:
                 '--homepage=about:blank', '--disable-direct-npapi-requests',
                 '--disable-web-security', '--disable-notifications',
                 '--disable-extensions', '--disable-save-password-bubble']
-
+        if headless:
+            chrome_args.append('--headless')
         if disk_cache_dir:
             chrome_args.append('--disk-cache-dir=%s' % disk_cache_dir)
         if disk_cache_size:

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -307,6 +307,9 @@ def brozzler_worker(argv=None):
             '-n', '--max-browsers', dest='max_browsers', default='1',
             help='max number of chrome instances simultaneously browsing pages')
     arg_parser.add_argument(
+            '--headless', dest='headless', action='store_true', default=False,
+            help='use chrome in headless mode')
+    arg_parser.add_argument(
             '--proxy', dest='proxy', default=None, help='http proxy')
     arg_parser.add_argument(
             '--warcprox-auto', dest='warcprox_auto', action='store_true',
@@ -354,7 +357,7 @@ def brozzler_worker(argv=None):
     service_registry = doublethink.ServiceRegistry(rr)
     worker = brozzler.worker.BrozzlerWorker(
             frontier, service_registry, max_browsers=int(args.max_browsers),
-            chrome_exe=args.chrome_exe, proxy=args.proxy,
+            chrome_exe=args.chrome_exe, headless=headless, proxy=args.proxy,
             warcprox_auto=args.warcprox_auto,
             skip_extract_outlinks=args.skip_extract_outlinks,
             skip_visit_hashtags=args.skip_visit_hashtags,

--- a/brozzler/easy.py
+++ b/brozzler/easy.py
@@ -88,7 +88,9 @@ def _build_arg_parser(argv=None):
             type=int, default=1, help=(
                 'max number of chrome instances simultaneously '
                 'browsing pages'))
-
+    arg_parser.add_argument(
+            '--headless', dest='headless', action='store_true', default=False,
+            help='use chrome in headless mode')
     # pywb args
     arg_parser.add_argument(
             '--pywb-address', dest='pywb_address',
@@ -141,7 +143,7 @@ class BrozzlerEasyController:
         worker = brozzler.worker.BrozzlerWorker(
                 frontier, service_registry, chrome_exe=args.chrome_exe,
                 proxy='%s:%s' % self.warcprox_controller.proxy.server_address,
-                max_browsers=args.max_browsers)
+                max_browsers=args.max_browsers, headless=args.headless)
         return worker
 
     def _init_pywb(self, args):

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -50,7 +50,8 @@ class BrozzlerWorker:
             self, frontier, service_registry=None, max_browsers=1,
             chrome_exe="chromium-browser", warcprox_auto=False, proxy=None,
             skip_extract_outlinks=False, skip_visit_hashtags=False,
-            skip_youtube_dl=False, page_timeout=300, behavior_timeout=900):
+            skip_youtube_dl=False, page_timeout=300, behavior_timeout=900,
+            headless=False):
         self._frontier = frontier
         self._service_registry = service_registry
         self._max_browsers = max_browsers
@@ -66,7 +67,8 @@ class BrozzlerWorker:
         self._behavior_timeout = behavior_timeout
 
         self._browser_pool = brozzler.browser.BrowserPool(
-                max_browsers, chrome_exe=chrome_exe, ignore_cert_errors=True)
+            max_browsers, chrome_exe=chrome_exe, headless=headless,
+            ignore_cert_errors=True)
         self._browsing_threads = set()
         self._browsing_threads_lock = threading.Lock()
 

--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -114,14 +114,14 @@ def test_httpd(httpd):
 
 def test_aw_snap_hes_dead_jim():
     chrome_exe = brozzler.suggest_default_chrome_exe()
-    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+    with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
         with pytest.raises(brozzler.BrowsingException):
             browser.browse_page('chrome://crash')
 
 def test_page_interstitial_exception(httpd):
     chrome_exe = brozzler.suggest_default_chrome_exe()
     url = 'http://localhost:%s/401' % httpd.server_port
-    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+    with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
         with pytest.raises(brozzler.PageInterstitialShown):
             browser.browse_page(url)
 
@@ -132,7 +132,7 @@ def test_on_response(httpd):
 
     chrome_exe = brozzler.suggest_default_chrome_exe()
     url = 'http://localhost:%s/site3/page.html' % httpd.server_port
-    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+    with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
         browser.browse_page(url, on_response=on_response)
     assert response_urls[0] == 'http://localhost:%s/site3/page.html' % httpd.server_port
     assert response_urls[1] == 'http://localhost:%s/site3/brozzler.svg' % httpd.server_port
@@ -141,7 +141,7 @@ def test_on_response(httpd):
 def test_420(httpd):
     chrome_exe = brozzler.suggest_default_chrome_exe()
     url = 'http://localhost:%s/420' % httpd.server_port
-    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+    with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
         with pytest.raises(brozzler.ReachedLimit) as excinfo:
             browser.browse_page(url)
         assert excinfo.value.warcprox_meta == WARCPROX_META_420
@@ -149,7 +149,7 @@ def test_420(httpd):
 def test_js_dialogs(httpd):
     chrome_exe = brozzler.suggest_default_chrome_exe()
     url = 'http://localhost:%s/site4/alert.html' % httpd.server_port
-    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+    with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
         # before commit d2ed6b97a24 these would hang and eventually raise
         # brozzler.browser.BrowsingTimeout, which would cause this test to fail
         browser.browse_page(
@@ -170,7 +170,7 @@ def test_page_videos(httpd):
     site = brozzler.Site(None, {})
     page = brozzler.Page(None, {
         'url':'http://localhost:%s/site6/' % httpd.server_port})
-    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+    with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
         worker.brozzle_page(browser, site, page)
     assert page.videos
     assert len(page.videos) == 4
@@ -211,7 +211,7 @@ def test_extract_outlinks(httpd):
     site = brozzler.Site(None, {})
     page = brozzler.Page(None, {
         'url':'http://localhost:%s/site8/' % httpd.server_port})
-    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+    with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
         outlinks = worker.brozzle_page(browser, site, page)
     assert outlinks == {
         'http://example.com/offsite',
@@ -238,10 +238,10 @@ def test_proxy_down():
         page = brozzler.Page(None, {'url': 'http://example.com/'})
 
         worker = brozzler.BrozzlerWorker(
-                frontier=None, proxy=not_listening_proxy)
+                frontier=None, proxy=not_listening_proxy, headless=True)
         chrome_exe = brozzler.suggest_default_chrome_exe()
 
-        with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+        with brozzler.Browser(chrome_exe=chrome_exe, headless=True) as browser:
             with pytest.raises(brozzler.ProxyError):
                 worker.brozzle_page(browser, site, page)
 


### PR DESCRIPTION
Using `--headless` chromium-browser option, we run all Brozzler without
requiring an X display.
https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md

Benchmarks are ~20% faster using `--headless`.

This option was introduced in chromium-browser 59 but was unstable. I've
tested it with v73.0.3683.86 and its running well.

With this PR, we add it as an option that is disabled by default.