### PR TITLE
Fix test_brozzling::httpd fixture

### DIFF
--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -67,8 +67,8 @@ def httpd(request):
                 self.send_header('WWW-Authenticate', 'Basic realm=\"Test\"')
                 self.send_header('Content-type', 'text/html')
                 self.end_headers()
-                self.wfile.write(self.headers.getheader('Authorization'))
-                self.wfile.write('not authenticated')
+                self.wfile.write(self.headers.get('Authorization', b''))
+                self.wfile.write(b'not authenticated')
             else:
                 super().do_GET()
 


### PR DESCRIPTION
We used `self.headers.getheader` which no longer works. We replace it
with `self.headers.get`.

We change the code to write binary data to `self.wfile` because we get
an exception for writing str and/or None.