### PR TITLE
Block AMP analytics JS script

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -354,11 +354,12 @@ class Browser:
             self.send_to_chrome(method='ServiceWorker.enable')
             self.send_to_chrome(method='ServiceWorker.setForceUpdateOnPageLoad')
 
-            # disable google analytics
+            # disable google analytics and amp analytics
             self.send_to_chrome(
                 method='Network.setBlockedURLs',
                 params={'urls': ['*google-analytics.com/analytics.js',
-                                 '*google-analytics.com/ga.js']})
+                                 '*google-analytics.com/ga.js',
+                                 '*cdn.ampproject.org/*/amp-analytics*.js']})
 
     def stop(self):
         '''


### PR DESCRIPTION
AMP analytics is part of Google analytics. We need to block it for
similar reasons. Current URL is
```
https://cdn.ampproject.org/v0/amp-analytics-0.1.js
```
but we have also seen:
```
https://cdn.ampproject.org/rtv/011906111828200/v0/amp-analytics-0.1.js
```
That's why we suggest the following pattern to block both:
```
*cdn.ampproject.org/*/amp-analytics*.js
```

AMP analytics reference:

https://developers.google.com/analytics/devguides/collection/amp-analytics/