### PR TITLE
More accurate JS behavior timeout

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -617,6 +617,7 @@ class Browser:
                 method='Runtime.evaluate', suppress_logging=True,
                 params={'expression': behavior_script})
 
+        check_interval = min(timeout, 7)
         start = time.time()
         while True:
             elapsed = time.time() - start
@@ -625,7 +626,7 @@ class Browser:
                         'behavior reached hard timeout after %.1fs', elapsed)
                 return
 
-            brozzler.sleep(7)
+            brozzler.sleep(check_interval)
 
             self.websock_thread.expect_result(self._command_id.peek())
             msg_id = self.send_to_chrome(


### PR DESCRIPTION
If you use a JS behavior timeout smaller than 7 sec, the JS behavior
will always need 7 sec because `sleep(7)` is hard-coded there.

We make a minor addition to use `min(timeout, 7)` for sleep so it will
finish faster when using a smaller JS behavior timeout.