### PR TITLE
Add support for Facebook ads library and fix closing

### DIFF
--- a/brozzler/behaviors.yaml
+++ b/brozzler/behaviors.yaml
@@ -18,6 +18,15 @@
 
 # first matched behavior is used, so order matters here
 -
+  url_regex: '^https?://(?:www\.)?facebook\.com/ads/library/.*$'
+  behavior_js_template: umbraBehavior.js.j2
+  request_idle_timeout_sec: 30
+  default_parameters:
+    interval: 500
+    actions:
+      - selector: 'a[data-testid="snapshot_footer_link"]'
+        closeSelector: 'div._7lq1 > button'
+-
   url_regex: '^https?://(?:www\.)?facebook\.com/.*$'
   behavior_js_template: facebook.js
   request_idle_timeout_sec: 30

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -617,6 +617,7 @@ class Browser:
                 method='Runtime.evaluate', suppress_logging=True,
                 params={'expression': behavior_script})
 
+        check_interval = min(timeout, 7)
         start = time.time()
         while True:
             elapsed = time.time() - start
@@ -625,7 +626,7 @@ class Browser:
                         'behavior reached hard timeout after %.1fs', elapsed)
                 return
 
-            brozzler.sleep(7)
+            brozzler.sleep(check_interval)
 
             self.websock_thread.expect_result(self._command_id.peek())
             msg_id = self.send_to_chrome(

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -250,10 +250,16 @@ class Chrome:
         # XXX select doesn't work on windows
         def readline_nonblock(f):
             buf = b''
-            while not self._shutdown.is_set() and (
+            try:
+                while not self._shutdown.is_set() and (
                     len(buf) == 0 or buf[-1] != 0xa) and select.select(
                             [f],[],[],0.5)[0]:
-                buf += f.read(1)
+                    buf += f.read(1)
+            except (ValueError, OSError):
+                # When the chrome process crashes, stdout & stderr are closed
+                # and trying to read from them raises these exceptions. We just
+                # stop reading and return current `buf`.
+                pass
             return buf
 
         try:

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -154,9 +154,9 @@ class UmbraBehavior {
         // an element we want to open. No need to track
         // the close selectors
         if (type == "open") {
+            this.idleSince = null;
             this.alreadyDone.push(target);
         }
-        this.idleSince = null;
     }
 
     start() {

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -43,6 +43,7 @@ class UmbraBehavior {
 
         var documents = [];
         documents[0] = document;
+
         var iframes = document.querySelectorAll("iframe");
         var iframesLength = iframes.length;
         for (var i = 0; i < iframesLength; i++) {
@@ -54,25 +55,27 @@ class UmbraBehavior {
                 // console.log("exception looking at iframe" + iframes[i] + ": " + e);
             }
         }
+
         var documentsLength = documents.length;
         for (var j = 0; j < documentsLength; j++) {
             if (closeSelector) {
                 var closeTargets = documents[j].querySelectorAll(closeSelector);
-                if ((closeTargets.length > 0) &&
-                    (this.alreadyDone.indexOf(closeTargets[0]) === -1) &&
-                    (this.isVisible(closeTargets[0]))) {
-                    doTarget(closeTargets[0], 'click');
+                for (var i = 0; i < closeTargets.length; i++) {
+                    this.doTarget(closeTargets[i], "click", "close");
                 }
             }
+
             if (firstMatchOnly) {
                 var doTargets = [ documents[j].querySelector(selector) ];
             } else {
                 var doTargets = documents[j].querySelectorAll(selector);
             }
+
             var doTargetsLength = doTargets.length;
             if (!(doTargetsLength > 0)) {
                 continue;
             }
+
             for ( var i = 0; i < doTargetsLength; i++) {
                 if (!repeatSameElement && this.alreadyDone.indexOf(doTargets[i]) > -1) {
                     continue;
@@ -82,7 +85,7 @@ class UmbraBehavior {
                 }
                 var where = this.aboveBelowOrOnScreen(doTargets[i]);
                 if (where == 0) {
-                    this.doTarget(doTargets[i], action);
+                    this.doTarget(doTargets[i], action, 'open');
                     didSomething = true;
                     break;
                 } else if (where > 0) {
@@ -133,7 +136,7 @@ class UmbraBehavior {
         return elem && !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
     }
 
-    doTarget(target, action) {
+    doTarget(target, action, type) {
         // console.log("doing " + action + target.outerHTML);
         // do mouse over event on target
         // since some urls are requsted only on
@@ -147,7 +150,12 @@ class UmbraBehavior {
             target.click();
         } // add new do's here!
 
-        this.alreadyDone.push(target);
+        // Only push the element to alreadyDone if it's
+        // an element we want to open. No need to track
+        // the close selectors
+        if (type == "open") {
+            this.alreadyDone.push(target);
+        }
         this.idleSince = null;
     }
 


### PR DESCRIPTION
This pull request add support for the Facebook ads Library available at: https://www.facebook.com/ads/library/

The behavior added is to open and close the detailed metrics of each ads.

In addition to that, I've also added a fix to the closing mechanism, a missing `this.` to a call of the method `doTarget` prevented Brozzler from using the selectors specified in `closeSelector`, in my testings, no closing selectors were used, ever.

I have also added a new argument to the `doTarget` method specifying if the target is an open or a close element, this new argument is used to prevent closing selectors from being added to the `alreadyDone` array, we do not want/need to keep track of the closing selectors used.

Thanks!