### PR TITLE
Improve exception handling when reading STDIN/STDERR

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -250,10 +250,16 @@ class Chrome:
         # XXX select doesn't work on windows
         def readline_nonblock(f):
             buf = b''
-            while not self._shutdown.is_set() and (
+            try:
+                while not self._shutdown.is_set() and (
                     len(buf) == 0 or buf[-1] != 0xa) and select.select(
                             [f],[],[],0.5)[0]:
-                buf += f.read(1)
+                    buf += f.read(1)
+            except (ValueError, OSError):
+                # When the chrome process crashes, stdout & stderr are closed
+                # and trying to read from them raises these exceptions. We just
+                # stop reading and return current `buf`.
+                pass
             return buf
 
         try:


### PR DESCRIPTION
When the chrome process dies and we try to read STDIN/STDERR, we get
`ValueError: I/O operation on closed file` or
`OSError: [Errno 9] Bad file descriptor`.

We modify `readline_nonblock` method to return the buffer it read up to
this point.