### PR TITLE
Add support for Facebook ads library and fix closing

### DIFF
--- a/brozzler/behaviors.yaml
+++ b/brozzler/behaviors.yaml
@@ -18,6 +18,15 @@
 
 # first matched behavior is used, so order matters here
 -
+  url_regex: '^https?://(?:www\.)?facebook\.com/ads/library/.*$'
+  behavior_js_template: umbraBehavior.js.j2
+  request_idle_timeout_sec: 30
+  default_parameters:
+    interval: 500
+    actions:
+      - selector: 'a[data-testid="snapshot_footer_link"]'
+        closeSelector: 'div._7lq1 > button'
+-
   url_regex: '^https?://(?:www\.)?facebook\.com/.*$'
   behavior_js_template: facebook.js
   request_idle_timeout_sec: 30

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -152,9 +152,6 @@ class UmbraBehavior {
             target.click();
         } // add new do's here!
 
-        // Only push the element to alreadyDone if it's
-        // an element we want to open. No need to track
-        // the close selectors
         this.alreadyDone.push(target);
         this.idleSince = null;
     }

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -63,6 +63,8 @@ class UmbraBehavior {
                 for (var i = 0; i < closeTargets.length; i++) {
                     if (this.isVisible(closeTargets[i])) {
                         closeTargets[i].click();
+                        didSomething = true;
+                        break;
                     }
                 }
             }

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -61,7 +61,9 @@ class UmbraBehavior {
             if (closeSelector) {
                 var closeTargets = documents[j].querySelectorAll(closeSelector);
                 for (var i = 0; i < closeTargets.length; i++) {
-                    this.doTarget(closeTargets[i], "click", "close");
+                    if (this.isVisible(closeTargets[i])) {
+                        closeTargets[i].click();
+                    }
                 }
             }
 
@@ -85,7 +87,7 @@ class UmbraBehavior {
                 }
                 var where = this.aboveBelowOrOnScreen(doTargets[i]);
                 if (where == 0) {
-                    this.doTarget(doTargets[i], action, 'open');
+                    this.doTarget(doTargets[i], action);
                     didSomething = true;
                     break;
                 } else if (where > 0) {
@@ -136,7 +138,7 @@ class UmbraBehavior {
         return elem && !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
     }
 
-    doTarget(target, action, type) {
+    doTarget(target, action) {
         // console.log("doing " + action + target.outerHTML);
         // do mouse over event on target
         // since some urls are requsted only on
@@ -153,9 +155,7 @@ class UmbraBehavior {
         // Only push the element to alreadyDone if it's
         // an element we want to open. No need to track
         // the close selectors
-        if (type == "open") {
-            this.alreadyDone.push(target);
-        }
+        this.alreadyDone.push(target);
         this.idleSince = null;
     }
 

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -43,6 +43,7 @@ class UmbraBehavior {
 
         var documents = [];
         documents[0] = document;
+
         var iframes = document.querySelectorAll("iframe");
         var iframesLength = iframes.length;
         for (var i = 0; i < iframesLength; i++) {
@@ -54,25 +55,27 @@ class UmbraBehavior {
                 // console.log("exception looking at iframe" + iframes[i] + ": " + e);
             }
         }
+
         var documentsLength = documents.length;
         for (var j = 0; j < documentsLength; j++) {
             if (closeSelector) {
                 var closeTargets = documents[j].querySelectorAll(closeSelector);
-                if ((closeTargets.length > 0) &&
-                    (this.alreadyDone.indexOf(closeTargets[0]) === -1) &&
-                    (this.isVisible(closeTargets[0]))) {
-                    doTarget(closeTargets[0], 'click');
+                for (var i = 0; i < closeTargets.length; i++) {
+                    this.doTarget(closeTargets[i], "click", "close");
                 }
             }
+
             if (firstMatchOnly) {
                 var doTargets = [ documents[j].querySelector(selector) ];
             } else {
                 var doTargets = documents[j].querySelectorAll(selector);
             }
+
             var doTargetsLength = doTargets.length;
             if (!(doTargetsLength > 0)) {
                 continue;
             }
+
             for ( var i = 0; i < doTargetsLength; i++) {
                 if (!repeatSameElement && this.alreadyDone.indexOf(doTargets[i]) > -1) {
                     continue;
@@ -82,7 +85,7 @@ class UmbraBehavior {
                 }
                 var where = this.aboveBelowOrOnScreen(doTargets[i]);
                 if (where == 0) {
-                    this.doTarget(doTargets[i], action);
+                    this.doTarget(doTargets[i], action, 'open');
                     didSomething = true;
                     break;
                 } else if (where > 0) {
@@ -133,7 +136,7 @@ class UmbraBehavior {
         return elem && !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
     }
 
-    doTarget(target, action) {
+    doTarget(target, action, type) {
         // console.log("doing " + action + target.outerHTML);
         // do mouse over event on target
         // since some urls are requsted only on
@@ -147,7 +150,12 @@ class UmbraBehavior {
             target.click();
         } // add new do's here!
 
-        this.alreadyDone.push(target);
+        // Only push the element to alreadyDone if it's
+        // an element we want to open. No need to track
+        // the close selectors
+        if (type == "open") {
+            this.alreadyDone.push(target);
+        }
         this.idleSince = null;
     }
 


### PR DESCRIPTION
Initial PR: https://github.com/internetarchive/brozzler/pull/163

This pull request add support for the Facebook ads Library available at: https://www.facebook.com/ads/library/

The behavior added is to open and close the detailed metrics of each ads.

In addition to that, I've also added a fix to the closing mechanism, and based on @nlevitt comments, the closing now doesn't use doTarget anymore.

Thanks!