### PR TITLE
Enable Console and Runtime outputs only when debugging

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -349,8 +349,12 @@ class Browser:
             # tell browser to send us messages we're interested in
             self.send_to_chrome(method='Network.enable')
             self.send_to_chrome(method='Page.enable')
-            self.send_to_chrome(method='Console.enable')
-            self.send_to_chrome(method='Runtime.enable')
+            # Enable Console & Runtime output only when debugging.
+            # After all, we just print these events with debug(), we don't use
+            # them in Brozzler logic.
+            if self.logger.isEnabledFor(logging.DEBUG):
+                self.send_to_chrome(method='Console.enable')
+                self.send_to_chrome(method='Runtime.enable')
             self.send_to_chrome(method='ServiceWorker.enable')
             self.send_to_chrome(method='ServiceWorker.setForceUpdateOnPageLoad')
 


### PR DESCRIPTION
When capturing a page, we receive a lot of messages from chrome.
Examining these message, we see that we can reduce them a bit to speed
up Brozzler.

We always use `Console.enable` which returns all browser console output.
Also, we always use `Runtime.enable`. Doc says:
https://chromedevtools.github.io/devtools-protocol/1-3/Runtime#method-enable

Enables reporting of execution contexts creation by means of
executionContextCreated event. When the reporting gets enabled the event
will be sent immediately for each existing execution context.

These outputs are useful when debugging but not in production.
If we disable them, we reduce the websocket traffic and improve
performance. With this PR, we enable them only when the current logging
level is `DEBUG`.

Counting the number of messages before and after the change, we see
improvements like:

https://www.gnome.org/technologies/ 220 -> 202 messages.

https://www.whitehouse.gov/issues/budget-spending/  203 -> 189 messages