### PR TITLE
Add option to specify port and interface binding on brozzler-dashboard

### DIFF
--- a/brozzler/dashboard/__init__.py
+++ b/brozzler/dashboard/__init__.py
@@ -44,6 +44,8 @@ SETTINGS = {
     'RETHINKDB_DB': os.environ.get('BROZZLER_RETHINKDB_DB', 'brozzler'),
     'WAYBACK_BASEURL': os.environ.get(
         'WAYBACK_BASEURL', 'http://localhost:8880/brozzler'),
+    'DASHBOARD_PORT': os.environ.get('DASHBOARD_PORT', '8000'),
+    'DASHBOARD_INTERFACE': os.environ.get('DASHBOARD_INTERFACE', 'localhost')
 }
 rr = doublethink.Rethinker(
         SETTINGS['RETHINKDB_SERVERS'], db=SETTINGS['RETHINKDB_DB'])
@@ -268,7 +270,7 @@ try:
 except ImportError:
     def run():
         logging.info("running brozzler-dashboard using simple flask app.run")
-        app.run()
+        app.run(host=SETTINGS['DASHBOARD_INTERFACE'], port=SETTINGS['DASHBOARD_PORT'])
 
 def main(argv=None):
     import argparse
@@ -289,7 +291,9 @@ def main(argv=None):
                 '  BROZZLER_RETHINKDB_DB        rethinkdb database name '
                 '(default: brozzler)\n'
                 '  WAYBACK_BASEURL     base url for constructing wayback '
-                'links (default http://localhost:8880/brozzler)'))
+                'links (default http://localhost:8880/brozzler)'
+                '  DASHBOARD_PORT   brozzler-dashboard listening port (default: 8000)\n'
+                '  DASHBOARD_INTERFACE brozzler-dashboard network interface binding (default: localhost)'))
     brozzler.cli.add_common_options(arg_parser, argv)
     args = arg_parser.parse_args(args=argv[1:])
     brozzler.cli.configure_logging(args)


### PR DESCRIPTION
Is this helpful?? I want to be able to expose brozzler-dashboard to other interfaces and ports. Any reason for not having this?