### PR TITLE
Add childSelector action

### DIFF
--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -33,6 +33,7 @@ class UmbraBehavior {
         // should match older default and simpleclicks behavior, and more
         var k = this.index;
         var selector = this.actions[k].selector;
+        var childSelector = this.actions[k].childSelector;
         var repeatSameElement = this.actions[k].repeatSameElement ? this.actions[k].repeatSameElement : false;
         var firstMatchOnly = this.actions[k].firstMatchOnly ? this.actions[k].firstMatchOnly : false;
         var action = this.actions[k].do ? this.actions[k].do : 'click';
@@ -90,6 +91,17 @@ class UmbraBehavior {
                 var where = this.aboveBelowOrOnScreen(doTargets[i]);
                 if (where == 0) {
                     this.doTarget(doTargets[i], action);
+                    if (childSelector) {
+                        var childSelectors = documents[j].querySelectorAll(childSelector);
+                        while (childSelectors.length > 0) {
+                            for (var i = 0; i < childSelectors.length; i++) {
+                                if (this.isVisible(childSelectors[i])) {
+                                    childSelectors[i].click();
+                                }
+                            }
+                            childSelectors = documents[j].querySelectorAll(childSelector);
+                        }
+                    }
                     didSomething = true;
                     break;
                 } else if (where > 0) {


### PR DESCRIPTION
This pull request add a new action for the behavior system. 

This action is named `childSelector` (I'm open to any better name!) and is executed after `selector` and before `closeSelector`.