### PR TITLE
Add capture of Facebook ads variants

### DIFF
--- a/brozzler/behaviors.yaml
+++ b/brozzler/behaviors.yaml
@@ -22,9 +22,10 @@
   behavior_js_template: umbraBehavior.js.j2
   request_idle_timeout_sec: 30
   default_parameters:
-    interval: 500
+    interval: 1000
     actions:
-      - selector: 'a[data-testid="snapshot_footer_link"]'
+      - selector: a[data-testid="snapshot_footer_link"]
+        childSelector: i[class="_271o img sp_fqSuadPtkdx sx_6986f4"]
         closeSelector: 'div._7lq1 > button'
 -
   url_regex: '^https?://(?:www\.)?facebook\.com/.*$'

--- a/brozzler/js-templates/umbraBehavior.js.j2
+++ b/brozzler/js-templates/umbraBehavior.js.j2
@@ -33,6 +33,7 @@ class UmbraBehavior {
         // should match older default and simpleclicks behavior, and more
         var k = this.index;
         var selector = this.actions[k].selector;
+        var childSelector = this.actions[k].childSelector;
         var repeatSameElement = this.actions[k].repeatSameElement ? this.actions[k].repeatSameElement : false;
         var firstMatchOnly = this.actions[k].firstMatchOnly ? this.actions[k].firstMatchOnly : false;
         var action = this.actions[k].do ? this.actions[k].do : 'click';
@@ -90,6 +91,17 @@ class UmbraBehavior {
                 var where = this.aboveBelowOrOnScreen(doTargets[i]);
                 if (where == 0) {
                     this.doTarget(doTargets[i], action);
+                    if (childSelector) {
+                        var childSelectors = documents[j].querySelectorAll(childSelector);
+                        while (childSelectors.length > 0) {
+                            for (var i = 0; i < childSelectors.length; i++) {
+                                if (this.isVisible(childSelectors[i])) {
+                                    childSelectors[i].click();
+                                }
+                            }
+                            childSelectors = documents[j].querySelectorAll(childSelector);
+                        }
+                    }
                     didSomething = true;
                     break;
                 } else if (where > 0) {


### PR DESCRIPTION
This PR ads the capture of FB Library ads variants.

It needs the `childSelector` action proposed in this pull request: https://github.com/internetarchive/brozzler/pull/176
