### PR TITLE
Fix Facebook Ads Library variants selector

### DIFF
--- a/brozzler/behaviors.yaml
+++ b/brozzler/behaviors.yaml
@@ -25,7 +25,7 @@
     interval: 1000
     actions:
       - selector: a[data-testid="snapshot_footer_link"]
-        childSelector: i[class="_271o img sp_fqSuadPtkdx sx_6986f4"]
+        childSelector: i[class="_271o img sp_-vbjDsgypf1 sx_1de63f"]
         closeSelector: 'div._7lq1 > button'
 -
   url_regex: '^https?://(?:www\.)?facebook\.com/.*$'


### PR DESCRIPTION
Fix the CSS class needed to click variants ads on the Facebook ads Library due to recent Facebook changes.

Example link for this selector: https://www.facebook.com/ads/library/?active_status=all&ad_type=political_and_issue_ads&country=ALL&impression_search_field=has_impressions_lifetime&q=Rhubarb