### PR TITLE
Enable running in docker / k8s

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -170,7 +170,7 @@ class Chrome:
                 '--disable-background-networking',
                 '--disable-renderer-backgrounding', '--disable-hang-monitor',
                 '--disable-background-timer-throttling', '--mute-audio',
-                '--disable-web-sockets',
+                '--disable-web-sockets', '--no-sandbox',
                 '--window-size=1100,900', '--no-default-browser-check',
                 '--disable-first-run-ui', '--no-first-run',
                 '--homepage=about:blank', '--disable-direct-npapi-requests',

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -179,7 +179,7 @@ class Chrome:
 
         extra_chrome_args = os.environ.get('BROZZLER_EXTRA_CHROME_ARGS')
         if extra_chrome_args:
-            chrome_args.append(extra_chrome_args)
+            chrome_args.extend(extra_chrome_args.split())
         if disk_cache_dir:
             chrome_args.append('--disk-cache-dir=%s' % disk_cache_dir)
         if disk_cache_size:

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -170,13 +170,16 @@ class Chrome:
                 '--disable-background-networking',
                 '--disable-renderer-backgrounding', '--disable-hang-monitor',
                 '--disable-background-timer-throttling', '--mute-audio',
-                '--disable-web-sockets', '--no-sandbox',
+                '--disable-web-sockets',
                 '--window-size=1100,900', '--no-default-browser-check',
                 '--disable-first-run-ui', '--no-first-run',
                 '--homepage=about:blank', '--disable-direct-npapi-requests',
                 '--disable-web-security', '--disable-notifications',
                 '--disable-extensions', '--disable-save-password-bubble']
 
+        extra_chrome_args = os.environ.get('BROZZLER_EXTRA_CHROME_ARGS')
+        if extra_chrome_args:
+            chrome_args.append(extra_chrome_args)
         if disk_cache_dir:
             chrome_args.append('--disk-cache-dir=%s' % disk_cache_dir)
         if disk_cache_size:


### PR DESCRIPTION
When trying to run Brozzler in docker, we get the following error:
```
Failed to move to new namespace: PID namespaces supported, Network
namespace supported, but failed: errno = Operation not permitted
Trace/breakpoint trap
```
This happens because chromium uses sandboxing for increased security by
default and its not supported when running in a container.
Adding chromium option `--no-sandbox` fixes the problem.

This issue is common, I found various reports about it like this:
https://github.com/Zenika/alpine-chrome/issues/33