### PR TITLE
Limit the number of times we try to navigate_to_page, then let it go

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -573,12 +573,16 @@ class Browser:
                     params={'userAgent': user_agent})
 
     def navigate_to_page(self, page_url, timeout=300):
-        self.logger.info('navigating to page %s', page_url)
-        self.websock_thread.got_page_load_event = None
-        self.send_to_chrome(method='Page.navigate', params={'url': page_url})
-        self._wait_for(
-                lambda: self.websock_thread.got_page_load_event,
-                timeout=timeout)
+        try:
+            for i in range(2):
+                self.logger.info('navigating to page %s', page_url)
+                self.websock_thread.got_page_load_event = None
+                self.send_to_chrome(method='Page.navigate', params={'url': page_url})
+                self._wait_for(
+                        lambda: self.websock_thread.got_page_load_event,
+                        timeout=timeout)
+        except BrowsingTimeout as e:
+            logging.error('attempt %s/2: %s', i + 1, e)
 
     def extract_outlinks(self, timeout=60):
         self.logger.info('extracting outlinks')


### PR DESCRIPTION
http://www.esf.org/esf_article.php?language=0&domain=1&activity=1&article=319&page=1059

While trying to brozzle the above page the job never finishes and hangs trying to brozzle that page.

After checking other issues and trying to figure it out it seems that the **Page.interstitialShown** is never fired. I have seen other reports here mentioning inconsistencies with the firing of this event.

In this specific case, it seems that the original page returns a 404 and it is a resource loaded by the 404 Not Found page that is requesting auth. If I try to directly brozzle one of these resource the Page.interstitialShown event is fired. 

Neverless! Should not Brozzler have a limited number of times that tries to navigate_to_page and then let it go? Or maybe to have that option?