### PR TITLE
consider page completed after 3 failures

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -286,6 +286,9 @@ import datetime
 EPOCH_UTC = datetime.datetime.utcfromtimestamp(0.0).replace(
         tzinfo=doublethink.UTC)
 
+# we could make this configurable if there's a good reason
+MAX_PAGE_FAILURES = 3
+
 from brozzler.worker import BrozzlerWorker
 from brozzler.robots import is_permitted_by_robots
 from brozzler.frontier import RethinkDbFrontier

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -405,7 +405,18 @@ class BrozzlerWorker:
                 logging.error(
                         'proxy error (self._proxy=%r)', self._proxy, exc_info=1)
         except:
-            self.logger.critical("unexpected exception", exc_info=True)
+            self.logger.error(
+                    'unexpected exception site=%r page=%r', site, page,
+                    exc_info=True)
+            if page:
+                page.failed_attempts = (page.failed_attempts or 0) + 1
+                if page.failed_attempts >= brozzler.MAX_PAGE_FAILURES:
+                    self.logger.info(
+                            'marking page "completed" after %s unexpected '
+                            'exceptions attempting to brozzle %s',
+                            page.failed_attempts, page)
+                    self._frontier.completed_page(site, page)
+                    page = None
         finally:
             if start:
                 site.active_brozzling_time = (site.active_brozzling_time or 0) + time.time() - start


### PR DESCRIPTION
https://github.com/internetarchive/brozzler/pull/183#issuecomment-560562807

"We've had a number of cases where a page kept failing for one reason or
another, and it's bad. We can end up with tons of duplicate captures,
the crawl is not able to make progress, and the overall performance of
the cluster is impacted in cases like yours, where a browser is sitting
there doing nothing for five minutes."