### PR TITLE
Expanding Brozzler's logging in capabilities

### DIFF
--- a/brozzler/js-templates/try-login.js.j2
+++ b/brozzler/js-templates/try-login.js.j2
@@ -1,8 +1,9 @@
 var __brzl_tryLoginState = 'trying';
 
 var __brzl_tryLogin = function() {
-    for(var x = 0; x < document.querySelectorAll("[class^='login-open']").length; x++){
-        button = document.querySelectorAll("[class^='login-open']")[x];
+    var login_open = document.querySelectorAll("[class^='login-open']");
+    for(var x = 0; x < login_open.length; x++){
+        button = login_open[x];
         button.click();
     }
 
@@ -53,15 +54,15 @@ var __brzl_tryLogin = function() {
             return;
         }
     }
-     
 
     if(__brzl_tryLoginState === 'trying'){
         var submit = undefined;
         var usernameInput = undefined;
         var passwordField = undefined;
+        var login = document.querySelectorAll("[class^='login']");
 
-        for (var z = 0; z < document.querySelectorAll("[class^='login']").length; z++){
-            var input = document.querySelectorAll("[class^='login']")[z];
+        for (var z = 0; z < login.length; z++){
+            var input = login[z];
 
             if (input.type === "text" || input.type == "email") {
                 usernameField = input;
@@ -75,7 +76,6 @@ var __brzl_tryLogin = function() {
                 break;
             }
         }
-
 
         if (submit && usernameField && passwordField){
             usernameField.value = {{username|json}};

--- a/brozzler/js-templates/try-login.js.j2
+++ b/brozzler/js-templates/try-login.js.j2
@@ -1,6 +1,11 @@
 var __brzl_tryLoginState = 'trying';
 
 var __brzl_tryLogin = function() {
+    for(var x = 0; x < document.querySelectorAll("[class^='login-open']").length; x++){
+        button = document.querySelectorAll("[class^='login-open']")[x];
+        button.click();
+    }
+
     for (var i = 0; i < document.forms.length; i++) {
         var form = document.forms[i];
         if (form.method != 'post') {
@@ -48,6 +53,39 @@ var __brzl_tryLogin = function() {
             return;
         }
     }
+     
+
+    if(__brzl_tryLoginState === 'trying'){
+        var submit = undefined;
+        var usernameInput = undefined;
+        var passwordField = undefined;
+
+        for (var z = 0; z < document.querySelectorAll("[class^='login']").length; z++){
+            var input = document.querySelectorAll("[class^='login']")[z];
+
+            if (input.type === "text" || input.type == "email") {
+                usernameField = input;
+            } else if (input.type === "password") {
+                passwordField = input;
+            }  else if(input.onclick != null) {
+                submit = input; 
+            } else if (input.type == "textarea") {
+                usernameField = undefined;
+                passwordField = undefined;
+                break;
+            }
+        }
+
+
+        if (submit && usernameField && passwordField){
+            usernameField.value = {{username|json}};
+            passwordField.value = {{password|json}};
+            submit.click();
+            __brzl_tryLoginState = 'maybe-submitted-form';
+            return;
+        }
+    }
+
     __brzl_tryLoginState = 'login-form-not-found';
 };
 

--- a/tests/htdocs/site11/form2.html
+++ b/tests/htdocs/site11/form2.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+    <title>brozzler login form test 2</title>
+</head>
+<body>
+    <div>
+        <a class="login-open-bt" onclick="document.getElementsByClassName('login-box')[0].style = '';">Sign In</li>
+            <div class="login-box" style="display: none;">
+                <div class="login-main">
+                    <ul class="login-list">
+                        <li>
+                            <input type="text" class="login-ipt" placeholder="Email" id="loginEmail">
+                        </li>
+                        <li>
+                            <input type="password" class="login-ipt" placeholder="Password" id="loginPsw">
+                        </li>
+                        <li>
+                            <div class="login-bt" onclick="window.location.href = '/login-action';">Sign In</div>
+                        </li>
+                        <br>
+                    </ul>
+                </div>
+            </div>
+</body>
+</html>

--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -267,6 +267,7 @@ def test_try_login(httpd):
         response_urls.append(msg['params']['response']['url'])
     chrome_exe = brozzler.suggest_default_chrome_exe()
     form_url = 'http://localhost:%s/site11/form1.html' % httpd.server_port
+    form_url_other = 'http://localhost:%s/site11/form2.html' % httpd.server_port
     favicon_url = 'http://localhost:%s/favicon.ico' % httpd.server_port
     login_url = 'http://localhost:%s/login-action' % httpd.server_port
     # When username and password are defined and initial page has login form,
@@ -281,6 +282,19 @@ def test_try_login(httpd):
     assert response_urls[1] == favicon_url
     assert response_urls[2] == login_url
     assert response_urls[3] == form_url
+
+    # We are now supporting a different type of form, we'll test that here.
+    response_urls = []
+    username = 'user1'
+    password = 'pass1'
+    with brozzler.Browser(chrome_exe=chrome_exe) as browser:
+        browser.browse_page(form_url_other, username=username, password=password,
+                            on_response=on_response)
+    assert len(response_urls) == 4
+    assert response_urls[0] == form_url_other
+    assert response_urls[1] == favicon_url
+    assert response_urls[2] == login_url
+    assert response_urls[3] == form_url_other
 
     # When username and password are not defined, just load the initial page.
     response_urls = []


### PR DESCRIPTION
Some sites don't allow you to login without clicking on a button to open a retracted modal.
This update to the login code allows Brozzler to click on all elements that we think are related to opening a login modal. Then, if there isn't a regular form, we will attempt to fill out abnormal form schemes. The test_try_login test has been expanded for the new type of login form we are supporting.