### PR TITLE
Login to paywalled site that uses a separate login page

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -111,12 +111,12 @@ def behaviors(behaviors_dir=None, conf='behaviors.yaml'):
             _behaviors = yaml.safe_load(fin)
     return _behaviors
 
-def behavior_script(url, template_parameters=None, behaviors_dir=None):
+def behavior_script(url, template_parameters=None, behaviors_dir=None, behaviors=None):
     '''
     Returns the javascript behavior string populated with template_parameters.
     '''
     import re, logging, json
-    for behavior in behaviors(behaviors_dir=behaviors_dir):
+    for behavior in behaviors:
         if re.match(behavior['url_regex'], url):
             parameters = dict()
             if 'default_parameters' in behavior:

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -94,17 +94,19 @@ def _logging_handler_handle(self, record):
 logging.Handler.handle = _logging_handler_handle
 
 _behaviors = None
-def behaviors(behaviors_dir=None):
+def behaviors(behaviors_dir=None, conf='behaviors.yaml'):
     """Return list of JS behaviors loaded from YAML file.
 
     :param behaviors_dir: Directory containing `behaviors.yaml` and
     `js-templates/`. Defaults to brozzler dir.
+    :param conf: The YAML definition of behaviors, it could also be
+    `login-behaviors.yaml` to load login action behaviors.
     """
     import os, yaml, string
     global _behaviors
     if _behaviors is None:
         d = behaviors_dir or os.path.dirname(__file__)
-        behaviors_yaml = os.path.join(d, 'behaviors.yaml')
+        behaviors_yaml = os.path.join(d, conf)
         with open(behaviors_yaml) as fin:
             _behaviors = yaml.safe_load(fin)
     return _behaviors

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -491,6 +491,15 @@ class Browser:
                         user_agent=user_agent)
                 self.navigate_to_page(page_url, timeout=page_timeout)
                 if password:
+                    login_behaviors = brozzler.behaviors(
+                        behaviors_dir=behaviors_dir, conf='login-behaviors.yaml'
+                        )
+                    login_behavior_script = brozzler.behavior_script(
+                            page_url, behavior_parameters,
+                            behaviors_dir=behaviors_dir,
+                            behaviors=login_behaviors)
+                    self.run_behavior(login_behavior_script,
+                                      timeout=behavior_timeout)
                     self.try_login(username, password, timeout=page_timeout)
                     # if login redirected us, return to page_url
                     if page_url != self.url().split('#')[0]:
@@ -509,9 +518,11 @@ class Browser:
                     run_behaviors = False
 
                 if run_behaviors:
+                    behaviors = brozzler.behaviors(behaviors_dir=behaviors_dir)
                     behavior_script = brozzler.behavior_script(
                             page_url, behavior_parameters,
-                            behaviors_dir=behaviors_dir)
+                            behaviors_dir=behaviors_dir,
+                            behaviors=behaviors)
                     self.run_behavior(behavior_script, timeout=behavior_timeout)
                 final_page_url = self.url()
                 if on_screenshot:

--- a/brozzler/js-templates/login-page.js.j2
+++ b/brozzler/js-templates/login-page.js.j2
@@ -1,0 +1,24 @@
+/*
+ * brozzler/js-templates/login-page.js.j2 - an umbra/brozzler behavior class
+ *
+ * Copyright (C) 2017-2019 Internet Archive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var __brzl_login_page_action = function() {
+    var actions = {{ actions|json }};
+    document.querySelector(actions[0].selector).click();
+};
+
+__brzl_login_page_action();

--- a/brozzler/login-behaviors.yaml
+++ b/brozzler/login-behaviors.yaml
@@ -1,0 +1,16 @@
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# first matched behavior is used, so order matters here
+-
+  url_regex: '^https?://(?:www\.)?thetimes\.co\.uk/.*$'
+  behavior_js_template: login-page.js.j2
+  request_idle_timeout_sec: 10
+  default_parameters:
+    actions:
+      - selector: a[href~='https://login.thetimes.co.uk']


### PR DESCRIPTION
Currently, Brozzler tries to login in a paywalled site if the login form is inside the target URL (`try_login` method).

The problem we are trying to resolve is that some times, the target URL is behind a paywall and you need to click the "Login" button to go to the login page, authenticate and then return to the target page.

We define a new `login-behaviors.yaml` where we can define rules to visit login pages for specific sites. We use as an example https://www.thetimes.co.uk.

We try to reuse existing code (`brozzler.behaviors`, `brozzler.behavior_script`).

Our code runs just before `try_login`. If the target site is defined in `login-behaviors.yaml`, we try to click on the "login" button (we find it using a selector) and then we run `try_login` as we already do.

The example we are using is not very good because `try_login` does not login successfully in https://account.thetimes.co.uk/ (we have valid credentials). This is the topic of another PR where we need to improve `try_login` to support it.

We are trying to make a correct login mechanism and then later add rules to `login-behaviors.yaml`.