### PR TITLE
Attempt to fix the tests

### DIFF
--- a/ansible/roles/brozzler-worker/tasks/main.yml
+++ b/ansible/roles/brozzler-worker/tasks/main.yml
@@ -58,7 +58,23 @@
 - name: mkdir {{venv_root}}/websockify-ve3
   become: true
   file: path={{venv_root}}/websockify-ve3 state=directory owner={{user}}
-
+ 
+#get python3 version for checks below 
+- shell: "python --version"
+  register: python_installed
+  
+ #websockify's dependency numpy's latest version no longer supports 3.5
+- name: install old version of numpy for websockify
+  pip:
+    name: numpy==1.18.4
+    virtualenv: '{{venv_root}}/websockify-ve3'
+    virtualenv_python: python3
+    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    extra_args: '--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'
+  become: true
+  become_user: '{{user}}'
+  when: '"Python 3.5" in python_installed.stdout'
+ 
 - name: install websockify in virtualenv
   pip:
     name: git+https://github.com/kanaka/websockify.git#egg=websockify

--- a/ansible/roles/rethinkdb/tasks/main.yml
+++ b/ansible/roles/rethinkdb/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: ensure rethinkdb apt public key is trusted
-  apt_key: url=http://download.rethinkdb.com/apt/pubkey.gpg
+  apt_key: url=https://download.rethinkdb.com/repository/raw/pubkey.gpg
   become: true
 - name: ensure rethinkdb repo is in apt sources.list
   apt_repository:
-    repo: 'deb http://download.rethinkdb.com/apt {{ansible_lsb.codename|lower}} main'
+    repo: 'deb https://download.rethinkdb.com/repository/ubuntu-{{ansible_lsb.codename|lower}} {{ansible_lsb.codename|lower}} main'
     state: present
   become: true
 - apt: update_cache=yes


### PR DESCRIPTION
RethinkDB wasn't installing, due to [a change in download servers.](https://rethinkdb.com/blog/download-server-changes) The latest version of Numpy no longer supports Python 3.5, so to maintain backwards compatibility, when Python 3.5 is being used we install a older version.

I'm still looking into the main test failure I've currently seen, test_no_proxy not passing due to Travis timing it out. Thanks!