### PR TITLE
readme: remove proxy from job configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,6 @@ however everything else is optional. For details, see `<job-conf.rst>`_.
 
     id: myjob
     time_limit: 60 # seconds
-    proxy: 127.0.0.1:8000 # point at warcprox for archiving
     ignore_robots: false
     warcprox_meta: null
     metadata: {}


### PR DESCRIPTION
It has been removed in 934190084c73699747cf3f4c4d2ee7e268927eae.