### PR TITLE
Skip loading behavior when behavior_timeout=0

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -509,7 +509,7 @@ class Browser:
                                    self.websock_thread.page_status >= 400):
                     run_behaviors = False
 
-                if run_behaviors:
+                if run_behaviors and behavior_timeout > 0:
                     behavior_script = brozzler.behavior_script(
                             page_url, behavior_parameters,
                             behaviors_dir=behaviors_dir)


### PR DESCRIPTION
The user may set `behavior_timeout=0`. This means that they don't want
to run the behavior. As it is now, Brozzler will invoke
`brozzler.behavior_script` to load the script and `self.run_behavior`
to execute it.
We will run the behavior using `Runtime.evaluate` but then it will be
terminated immediately because of timeout=0.

It is better to skip behavior loading and running when
`behavior_timeout=0`.