### PR TITLE
Fix problems with Ansible playbook in vagrant

### DIFF
--- a/ansible/roles/brozzler-worker/tasks/main.yml
+++ b/ansible/roles/brozzler-worker/tasks/main.yml
@@ -60,7 +60,7 @@
   file: path={{venv_root}}/websockify-ve3 state=directory owner={{user}}
  
 #get python3 version for checks below 
-- shell: "python --version"
+- shell: "python3 --version"
   register: python_installed
   
  #websockify's dependency numpy's latest version no longer supports 3.5

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -73,4 +73,4 @@
   user: name={{user}} system=yes createhome=no home=/nonexistent
         shell=/usr/sbin/nologin
   become: true
-  when: id_user|failed
+  when: id_user is failed


### PR DESCRIPTION
* `| failed` was [deprecated in Ansible 2.5](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters) and removed in 2.9
* The `python` dpkg alternative doesn't seem to be available by default, but we're only interested in python3 anyway.

With these two changes, `vagrant up` now runs successfully with the latest version of `ubuntu/xenial64` (v20210316.0.0).