### PR TITLE
ansible: fix deprecated use of apt+with_items

### DIFF
--- a/ansible/roles/brozzler-worker/tasks/main.yml
+++ b/ansible/roles/brozzler-worker/tasks/main.yml
@@ -9,32 +9,33 @@
 
 - name: ensure required packages are installed
   become: true
-  apt: name={{item}} state=present
-  with_items:
-  - chromium-browser
-  - vnc4server
-  - libjpeg-turbo8-dev
-  - zlib1g-dev
-  - gcc
-  - python3-dev
-  - python3-dbg
-  - adobe-flashplugin
-  - xfonts-base
-  - fonts-arphic-bkai00mp
-  - fonts-arphic-bsmi00lp
-  - fonts-arphic-gbsn00lp
-  - fonts-arphic-gkai00mp
-  - fonts-arphic-ukai
-  - fonts-farsiweb
-  - fonts-nafees
-  - fonts-sil-abyssinica
-  - fonts-sil-ezra
-  - fonts-sil-padauk
-  - fonts-unfonts-extra
-  - fonts-unfonts-core
-  - fonts-indic
-  - fonts-thai-tlwg
-  - fonts-lklug-sinhala
+  apt:
+    state: present
+    name:
+    - chromium-browser
+    - vnc4server
+    - libjpeg-turbo8-dev
+    - zlib1g-dev
+    - gcc
+    - python3-dev
+    - python3-dbg
+    - adobe-flashplugin
+    - xfonts-base
+    - fonts-arphic-bkai00mp
+    - fonts-arphic-bsmi00lp
+    - fonts-arphic-gbsn00lp
+    - fonts-arphic-gkai00mp
+    - fonts-arphic-ukai
+    - fonts-farsiweb
+    - fonts-nafees
+    - fonts-sil-abyssinica
+    - fonts-sil-ezra
+    - fonts-sil-padauk
+    - fonts-unfonts-extra
+    - fonts-unfonts-core
+    - fonts-indic
+    - fonts-thai-tlwg
+    - fonts-lklug-sinhala
 
 - name: mkdir /etc/service/{Xvnc,vnc-websock,brozzler-worker}
   file:

--- a/ansible/roles/warcprox/tasks/main.yml
+++ b/ansible/roles/warcprox/tasks/main.yml
@@ -1,14 +1,15 @@
 ---
 - name: ensure required packages are installed
   become: true
-  apt: name={{item}} state=present
-  with_items:
-  - gcc
-  - python3-dev
-  - libffi-dev
-  - libssl-dev
-  - tor
-  - git
+  apt:
+    state: present
+    name:
+    - gcc
+    - python3-dev
+    - libffi-dev
+    - libssl-dev
+    - tor
+    - git
 - name: mkdir {{venv_root}}/warcprox-ve3
   become: true
   file: path={{venv_root}}/warcprox-ve3 state=directory owner={{user}}


### PR DESCRIPTION
Per the notice:

    [DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
    squash_actions is deprecated. Instead of using a loop to supply multiple items
    and specifying `name: "{{item}}"`, please use `name: [...]` and remove the
    loop. This feature will be removed in version 2.11.