### PR TITLE
vagrant: more helpful error when vagrant-disksize plugin is missing

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,3 +1,7 @@
+unless Vagrant.has_plugin?("vagrant-disksize")
+  raise 'plugin vagrant-disksize is not installed!'
+end
+
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.define "10.9.9.9"


### PR DESCRIPTION
Without this, Vagrant just says "Unknown configuration section 'disksize'.", which error requires some investigation to determine a cause.