### PR TITLE
Add more stealth evasions

### DIFF
--- a/brozzler/js-templates/stealth.js
+++ b/brozzler/js-templates/stealth.js
@@ -14,6 +14,34 @@ WebGLRenderingContext.prototype.getParameter = function(origFn) {
   };
 }(WebGLRenderingContext.prototype.getParameter);
 
+// This is `Linux x86_64` on Linux.
+Object.defineProperty(navigator, 'platform', {
+    get: () => 'Win32'
+});
+
+// Randomize navigator.deviceMemory and navigator.hardwareConcurrency to evade
+// browser fingerprinting.
+function getRandomInt(min, max) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min) + min); //The maximum is exclusive and the minimum is inclusive
+}
+
+Object.defineProperty(navigator, 'deviceMemory', {
+    get: () => getRandomInt(4, 32)
+});
+Object.defineProperty(navigator, 'hardwareConcurrency', {
+    get: () => getRandomInt(4, 32)
+});
+
+// Brozzler runs chrome with --disable-notifications which disables `window.Notification`.
+// This object is used for web bot detection and should be there.
+if (!window.Notification) {
+  window.Notification = {
+    permission: 'denied'
+  }
+}
+
 // TODO Add many more feature detection evations here. For example:
 // Mock navigator.permissions.query. In headful on secure origins the
 // permission should be "default", not "denied".


### PR DESCRIPTION
Set `navigator.platform = 'Win32'` instead of the default `Linux` as we
usualy run Brozzler on Linux.

Randomize the `navigator.deviceMemory` and
`navigator.hardwareConcurrency` to avoid browser fingerprinting.

Define `window.Notification` which is not defined because we run Chrome
with CLI parameter `--disable-notifications`.