### PR TITLE
Update Ansible and Vagrant for Debian 12

### DIFF
--- a/ansible/roles/brozzler-dashboard/tasks/main.yml
+++ b/ansible/roles/brozzler-dashboard/tasks/main.yml
@@ -9,7 +9,7 @@
     name: '{{brozzler_pip_name}}[dashboard]'
     virtualenv: '{{venv_root}}/brozzler-dashboard-ve3'
     virtualenv_python: python3
-    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    virtualenv_command: python3 -mvirtualenv
     extra_args: '--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'
   become: true
   become_user: '{{user}}'

--- a/ansible/roles/brozzler-worker/tasks/main.yml
+++ b/ansible/roles/brozzler-worker/tasks/main.yml
@@ -51,7 +51,7 @@
   file: path={{venv_root}}/websockify-ve3 state=directory owner={{user}}
  
 #get python3 version for checks below 
-- shell: "python --version"
+- shell: "python3 --version"
   register: python_installed
   
  #websockify's dependency numpy's latest version no longer supports 3.5
@@ -60,7 +60,7 @@
     name: numpy==1.18.4
     virtualenv: '{{venv_root}}/websockify-ve3'
     virtualenv_python: python3
-    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    virtualenv_command: python3 -mvirtualenv
     extra_args: '--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'
   become: true
   become_user: '{{user}}'
@@ -71,7 +71,7 @@
     name: git+https://github.com/kanaka/websockify.git#egg=websockify
     virtualenv: '{{venv_root}}/websockify-ve3'
     virtualenv_python: python3
-    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    virtualenv_command: python3 -mvirtualenv
     extra_args: '--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'
   become: true
   become_user: '{{user}}'
@@ -94,7 +94,7 @@
     name: '{{brozzler_pip_name}}'
     virtualenv: '{{venv_root}}/brozzler-ve3'
     virtualenv_python: python3
-    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    virtualenv_command: python3 -mvirtualenv
     extra_args: '--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'
   become: true
   become_user: '{{user}}'

--- a/ansible/roles/brozzler-worker/tasks/main.yml
+++ b/ansible/roles/brozzler-worker/tasks/main.yml
@@ -1,24 +1,15 @@
 ---
-- name: ensure canonical partner repo is in apt sources.list
-  apt_repository: repo='deb http://archive.canonical.com/ubuntu trusty partner'
-                  state=present
-  become: true
-
-- apt: update_cache=yes
-  become: true
-
 - name: ensure required packages are installed
   become: true
   apt: name={{item}} state=present
   with_items:
-  - chromium-browser
-  - vnc4server
-  - libjpeg-turbo8-dev
+  - chromium
+  - tigervnc-standalone-server
+  - libjpeg62-turbo-dev
   - zlib1g-dev
   - gcc
   - python3-dev
   - python3-dbg
-  - adobe-flashplugin
   - xfonts-base
   - fonts-arphic-bkai00mp
   - fonts-arphic-bsmi00lp

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -70,7 +70,7 @@
   changed_when: false
 
 - name: ensure service user {{user}} exists
-  user: name={{user}} system=yes createhome=no home=/nonexistent
+  user: name={{user}} system=yes createhome=yes home=/home/{{user}}
         shell=/usr/sbin/nologin
   become: true
-  when: id_user|failed
+  when: id_user.rc != 0

--- a/ansible/roles/pywb/tasks/main.yml
+++ b/ansible/roles/pywb/tasks/main.yml
@@ -10,7 +10,7 @@
     version: 0.33.2
     virtualenv: '{{venv_root}}/pywb-ve3'
     virtualenv_python: python3
-    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    virtualenv_command: python3 -mvirtualenv
     extra_args: '--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'
   become: true
   become_user: '{{user}}'
@@ -22,7 +22,7 @@
     name: '{{brozzler_pip_name}}'
     virtualenv: '{{venv_root}}/pywb-ve3'
     virtualenv_python: python3
-    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    virtualenv_command: python3 -mvirtualenv
     extra_args: '--no-input --upgrade --pre --cache-dir=/tmp/pip-cache'
   become: true
   become_user: '{{user}}'

--- a/ansible/roles/pywb/templates/pywb-run.j2
+++ b/ansible/roles/pywb/templates/pywb-run.j2
@@ -5,6 +5,6 @@ touch $logfile
 chown {{user}} $logfile
 
 exec nice setuidgid {{user}} env PYWB_CONFIG_FILE=/etc/pywb.yml \
-    {{venv_root}}/pywb-ve3/bin/python {{venv_root}}/pywb-ve3/bin/brozzler-wayback \
+    {{venv_root}}/pywb-ve3/bin/python3 {{venv_root}}/pywb-ve3/bin/brozzler-wayback \
     >> $logfile 2>&1
 

--- a/ansible/roles/rethinkdb/tasks/main.yml
+++ b/ansible/roles/rethinkdb/tasks/main.yml
@@ -4,7 +4,7 @@
   become: true
 - name: ensure rethinkdb repo is in apt sources.list
   apt_repository:
-    repo: 'deb https://download.rethinkdb.com/repository/ubuntu-{{ansible_lsb.codename|lower}} {{ansible_lsb.codename|lower}} main'
+    repo: 'deb https://download.rethinkdb.com/repository/{{ansible_distribution|lower}}-{{ansible_lsb.codename|lower}} {{ansible_lsb.codename|lower}} main'
     state: present
   become: true
 - apt: update_cache=yes

--- a/ansible/roles/warcprox/tasks/main.yml
+++ b/ansible/roles/warcprox/tasks/main.yml
@@ -18,7 +18,7 @@
     virtualenv: '{{venv_root}}/warcprox-ve3'
     virtualenv_python: python3
     extra_args: --no-input --upgrade --pre --cache-dir=/tmp/pip-cache
-    virtualenv_command: python3 /usr/lib/python3/dist-packages/virtualenv.py
+    virtualenv_command: python3 -mvirtualenv
   become: true
   become_user: '{{user}}'
   notify:

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "generic/debian12"
   config.vm.define "10.9.9.9"
   config.vm.hostname = "brzl"
   config.vm.network :private_network, ip: "10.9.9.9"


### PR DESCRIPTION
Ubuntu no longer packages `chromium` as a .deb, only as a snap. Debian is keeping the .deb dream alive.

I've made the playbook more resilient to path changes with Python versions by using `-mvirtualenv` instead of executing the module file and using `python3` instead of expecting `python` on the system path to point to the right place.

This proposed PR would lose the ability to archive Adobe Flash as no equivalent is packaged (or would work with a modern Chromium, I think?)