### PR TITLE
Upgrade websocket-client dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
         "yt_dlp<2023.11.16",
         "reppy==0.3.4",
         "requests>=2.21",
-        "websocket-client>=0.39.0,<=0.48.0",
+        "websocket-client==0.59.0",
         "pillow>=5.2.0",
         "urlcanon>=0.1.dev23",
         "doublethink @ git+https://github.com/internetarchive/doublethink.git@Py311",


### PR DESCRIPTION
We use a very old version (0.47.0 was released on Feb 22, 2018). This project is actively developed so it would be great to upgrade. Changelog: https://github.com/websocket-client/websocket-client/blob/master/ChangeLog

I tested every version from 0.48.0 to 0.59.0.
Only versions 0.52.0, 0.58.0 and 0.59.0 worked correctly. All others raised exceptions. Thus, I suggest to use 0.59.0 for now.