### PR TITLE
Disable automatic http to https transformation

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -199,6 +199,7 @@ class Chrome:
             "--disable-first-run-ui",
             "--no-first-run",
             "--homepage=about:blank",
+            "--disable-features=HttpsUpgrades",
             "--disable-direct-npapi-requests",
             "--disable-web-security",
             "--disable-notifications",


### PR DESCRIPTION
Chrome 130 automatically converts http to https even if the target URL is http. We disable this behavior because some target sites simply don't have https.