### PR TITLE
Set up structlog logging

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -184,7 +184,9 @@ class ThreadExceptionGate:
     def __enter__(self):
         assert self.thread == threading.current_thread()
         if self.pending_exception:
-            self.logger.info("raising pending exception", pending_exception=self.pending_exception)
+            self.logger.info(
+                "raising pending exception", pending_exception=self.pending_exception
+            )
             tmp = self.pending_exception
             self.pending_exception = None
             raise tmp

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -123,7 +123,7 @@ def behavior_script(url, template_parameters=None, behaviors_dir=None):
     """
     import re, json
 
-    logger = structlog.get_logger()
+    logger = structlog.get_logger(logger_name=__name__)
 
     for behavior in behaviors(behaviors_dir=behaviors_dir):
         if re.match(behavior["url_regex"], url):

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -18,6 +18,7 @@ limitations under the License.
 """
 
 import logging
+import structlog
 from pkg_resources import get_distribution as _get_distribution
 
 __version__ = _get_distribution("brozzler").version
@@ -146,7 +147,9 @@ def behavior_script(url, template_parameters=None, behaviors_dir=None):
     """
     Returns the javascript behavior string populated with template_parameters.
     """
-    import re, logging, json
+    import re, json
+
+    logger = structlog.get_logger()
 
     for behavior in behaviors(behaviors_dir=behaviors_dir):
         if re.match(behavior["url_regex"], url):
@@ -159,18 +162,18 @@ def behavior_script(url, template_parameters=None, behaviors_dir=None):
                 behavior["behavior_js_template"]
             )
             script = template.render(parameters)
-            logging.info(
-                "using template=%r populated with parameters=%r for %r",
-                behavior["behavior_js_template"],
-                json.dumps(parameters),
-                url,
+            logger.info(
+                "rendering template",
+                template=behavior["behavior_js_template"],
+                parameters=json.dumps(parameters),
+                url=url,
             )
             return script
     return None
 
 
 class ThreadExceptionGate:
-    logger = logging.getLogger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(__module__ + "." + __qualname__)
 
     def __init__(self, thread):
         self.thread = thread
@@ -181,7 +184,7 @@ class ThreadExceptionGate:
     def __enter__(self):
         assert self.thread == threading.current_thread()
         if self.pending_exception:
-            self.logger.info("raising pending exception %s", self.pending_exception)
+            self.logger.info("raising pending exception", pending_exception=self.pending_exception)
             tmp = self.pending_exception
             self.pending_exception = None
             raise tmp
@@ -198,10 +201,10 @@ class ThreadExceptionGate:
         with self.lock:
             if self.pending_exception:
                 self.logger.warning(
-                    "%r already pending for thread %r, discarding %r",
-                    self.pending_exception,
-                    self.thread,
-                    e,
+                    "exception already pending for thread, discarding",
+                    pending_exception=self.pending_exception,
+                    thread=self.thread,
+                    exception=e,
                 )
             else:
                 self.pending_exception = e
@@ -266,7 +269,9 @@ def thread_raise(thread, exctype):
         TypeError if `exctype` is not a class
         ValueError, SystemError in case of unexpected problems
     """
-    import ctypes, inspect, threading, logging
+    import ctypes, inspect, threading, structlog
+
+    logger = structlog.get_logger(exctype=exctype, thread=thread)
 
     if not inspect.isclass(exctype):
         raise TypeError(
@@ -278,7 +283,7 @@ def thread_raise(thread, exctype):
     with gate.lock:
         if gate.ok_to_raise.is_set() and thread.is_alive():
             gate.ok_to_raise.clear()
-            logging.info("raising %s in thread %s", exctype, thread)
+            logger.info("raising exception in thread")
             res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
                 ctypes.c_long(thread.ident), ctypes.py_object(exctype)
             )
@@ -290,7 +295,7 @@ def thread_raise(thread, exctype):
                 ctypes.pythonapi.PyThreadState_SetAsyncExc(thread.ident, 0)
                 raise SystemError("PyThreadState_SetAsyncExc failed")
         else:
-            logging.info("queueing %s for thread %s", exctype, thread)
+            logger.info("queueing exception for thread")
             gate.queue_exception(exctype)
 
 

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -139,7 +139,7 @@ def behavior_script(url, template_parameters=None, behaviors_dir=None):
             logger.info(
                 "rendering template",
                 template=behavior["behavior_js_template"],
-                parameters=json.dumps(parameters),
+                parameters=parameters,
                 url=url,
             )
             return script

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -147,7 +147,7 @@ def behavior_script(url, template_parameters=None, behaviors_dir=None):
 
 
 class ThreadExceptionGate:
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     def __init__(self, thread):
         self.thread = thread

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -80,31 +80,6 @@ class ReachedLimit(Exception):
         return self.__repr__()
 
 
-# monkey-patch log levels TRACE and NOTICE
-logging.TRACE = (logging.NOTSET + logging.DEBUG) // 2
-
-
-def _logger_trace(self, msg, *args, **kwargs):
-    if self.isEnabledFor(logging.TRACE):
-        self._log(logging.TRACE, msg, args, **kwargs)
-
-
-logging.Logger.trace = _logger_trace
-logging.trace = logging.root.trace
-logging.addLevelName(logging.TRACE, "TRACE")
-
-logging.NOTICE = (logging.INFO + logging.WARN) // 2
-
-
-def _logger_notice(self, msg, *args, **kwargs):
-    if self.isEnabledFor(logging.NOTICE):
-        self._log(logging.NOTICE, msg, args, **kwargs)
-
-
-logging.Logger.notice = _logger_notice
-logging.notice = logging.root.notice
-logging.addLevelName(logging.NOTICE, "NOTICE")
-
 
 # see https://github.com/internetarchive/brozzler/issues/91
 def _logging_handler_handle(self, record):

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -180,7 +180,7 @@ class ThreadExceptionGate:
                     "exception already pending for thread, discarding",
                     pending_exception=self.pending_exception,
                     thread=self.thread,
-                    exception=e,
+                    discarded_exception=e,
                 )
             else:
                 self.pending_exception = e

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -80,7 +80,6 @@ class ReachedLimit(Exception):
         return self.__repr__()
 
 
-
 # see https://github.com/internetarchive/brozzler/issues/91
 def _logging_handler_handle(self, record):
     rv = self.filter(record)

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -717,9 +717,7 @@ class Browser:
                 # no links found
                 return frozenset()
         else:
-            self.logger.error(
-                "problem extracting outlinks", message=message
-            )
+            self.logger.error("problem extracting outlinks", message=message)
             return frozenset()
 
     def screenshot(self, full_page=False, timeout=45):

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -292,7 +292,7 @@ class WebsockReceiverThread(threading.Thread):
                     message["params"]["message"]["text"],
                 )
             elif message["method"] == "Runtime.exceptionThrown":
-                self.logger.debug("uncaught exception", exception=message)
+                self.logger.debug("uncaught exception", message=message)
             elif message["method"] == "Page.javascriptDialogOpening":
                 self._javascript_dialog_opening(message)
             elif (

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -31,6 +31,7 @@ import base64
 from ipaddress import AddressValueError
 from brozzler.chrome import Chrome
 import socket
+import structlog
 import urlcanon
 
 
@@ -52,7 +53,7 @@ class BrowserPool:
     debugging protocol.
     """
 
-    logger = logging.getLogger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(__module__ + "." + __qualname__)
 
     def __init__(self, size=3, **kwargs):
         """
@@ -143,7 +144,7 @@ class BrowserPool:
 
 
 class WebsockReceiverThread(threading.Thread):
-    logger = logging.getLogger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(__module__ + "." + __qualname__)
 
     def __init__(self, websock, name=None, daemon=True):
         super().__init__(name=name, daemon=daemon)
@@ -193,7 +194,7 @@ class WebsockReceiverThread(threading.Thread):
         ):
             self.logger.error("websocket closed, did chrome die?")
         else:
-            self.logger.error("exception from websocket receiver thread", exc_info=1)
+            self.logger.exception("exception from websocket receiver thread")
         brozzler.thread_raise(self.calling_thread, BrowsingException)
 
     def run(self):
@@ -213,10 +214,9 @@ class WebsockReceiverThread(threading.Thread):
         try:
             self._handle_message(websock, message)
         except:
-            self.logger.error(
-                "uncaught exception in _handle_message message=%s",
-                message,
-                exc_info=True,
+            self.logger.exception(
+                "uncaught exception in _handle_message",
+                message=message,
             )
 
     def _network_response_received(self, message):
@@ -231,7 +231,7 @@ class WebsockReceiverThread(threading.Thread):
                     ]
                 )
                 self.reached_limit = brozzler.ReachedLimit(warcprox_meta=warcprox_meta)
-                self.logger.info("reached limit %s", self.reached_limit)
+                self.logger.info("reached limit", limit=self.reached_limit)
                 brozzler.thread_raise(self.calling_thread, brozzler.ReachedLimit)
             else:
                 self.logger.info(
@@ -245,7 +245,7 @@ class WebsockReceiverThread(threading.Thread):
             self.page_status = status
 
     def _javascript_dialog_opening(self, message):
-        self.logger.info("javascript dialog opened: %s", message)
+        self.logger.info("javascript dialog opened", message=message)
         if message["params"]["type"] == "alert":
             accept = True
         else:
@@ -292,7 +292,7 @@ class WebsockReceiverThread(threading.Thread):
                     message["params"]["message"]["text"],
                 )
             elif message["method"] == "Runtime.exceptionThrown":
-                self.logger.debug("uncaught exception: %s", message)
+                self.logger.debug("uncaught exception", exception=message)
             elif message["method"] == "Page.javascriptDialogOpening":
                 self._javascript_dialog_opening(message)
             elif (
@@ -322,7 +322,7 @@ class Browser:
     Manages an instance of Chrome for browsing pages.
     """
 
-    logger = logging.getLogger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(__module__ + "." + __qualname__)
 
     def __init__(self, **kwargs):
         """
@@ -365,11 +365,10 @@ class Browser:
         msg_id = next(self._command_id)
         kwargs["id"] = msg_id
         msg = json.dumps(kwargs, separators=",:")
-        logging.log(
-            logging.TRACE if suppress_logging else logging.DEBUG,
-            "sending message to %s: %s",
-            self.websock,
-            msg,
+        self.logger.debug(
+            "sending message",
+            websock=self.websock,
+            message=msg,
         )
         self.websock.send(msg)
         return msg_id
@@ -397,7 +396,7 @@ class Browser:
             # Enable Console & Runtime output only when debugging.
             # After all, we just print these events with debug(), we don't use
             # them in Brozzler logic.
-            if self.logger.isEnabledFor(logging.DEBUG):
+            if self.logger.is_enabled_for(logging.DEBUG):
                 self.send_to_chrome(method="Console.enable")
                 self.send_to_chrome(method="Runtime.enable")
             self.send_to_chrome(method="ServiceWorker.enable")
@@ -432,8 +431,8 @@ class Browser:
                 try:
                     self.websock.close()
                 except BaseException as e:
-                    self.logger.error(
-                        "exception closing websocket %s - %s", self.websock, e
+                    self.logger.exception(
+                        "exception closing websocket", websocket=self.websock
                     )
 
             self.chrome.stop()
@@ -460,7 +459,7 @@ class Browser:
 
             self.websock_url = None
         except:
-            self.logger.error("problem stopping", exc_info=True)
+            self.logger.exception("problem stopping")
 
     def is_running(self):
         return self.websock_url is not None
@@ -566,7 +565,7 @@ class Browser:
                     # if login redirected us, return to page_url
                     if page_url != self.url().split("#")[0]:
                         self.logger.debug(
-                            "login navigated away from %s; returning!", page_url
+                            "login navigated away; returning!", page_url=page_url
                         )
                         self.navigate_to_page(page_url, timeout=page_timeout)
                 # If the target page HTTP status is 4xx/5xx, there is no point
@@ -608,7 +607,7 @@ class Browser:
             # more information, raise that one
             raise self.websock_thread.reached_limit
         except websocket.WebSocketConnectionClosedException as e:
-            self.logger.error("websocket closed, did chrome die?")
+            self.logger.exception("websocket closed, did chrome die?")
             raise BrowsingException(e)
         finally:
             self.is_browsing = False
@@ -630,7 +629,7 @@ class Browser:
                 on_screenshot(jpeg_bytes)
                 return
             except BrowsingTimeout as e:
-                logging.error("attempt %s/3: %s", i + 1, e)
+                self.logger.exception("attempt %s/3", i + 1)
 
     def visit_hashtags(self, page_url, hashtags, outlinks):
         _hashtags = set(hashtags or [])
@@ -644,7 +643,7 @@ class Browser:
         # out which hashtags were visited already and skip those
         for hashtag in _hashtags:
             # navigate_to_hashtag (nothing to wait for so no timeout?)
-            self.logger.debug("navigating to hashtag %s", hashtag)
+            self.logger.debug("navigating to hashtag", hashtag=hashtag)
             url = urlcanon.whatwg(page_url)
             url.hash_sign = b"#"
             url.fragment = hashtag[1:].encode("utf-8")
@@ -684,7 +683,7 @@ class Browser:
             )
 
     def navigate_to_page(self, page_url, timeout=300):
-        self.logger.info("navigating to page %s", page_url)
+        self.logger.info("navigating to page", page_url=page_url)
         self.websock_thread.got_page_load_event = None
         self.websock_thread.page_status = None
         self.send_to_chrome(method="Page.navigate", params={"url": page_url})
@@ -712,14 +711,14 @@ class Browser:
                     try:
                         out.append(str(urlcanon.whatwg(link)))
                     except AddressValueError:
-                        self.logger.warning("skip invalid outlink: %s", link)
+                        self.logger.warning("skip invalid outlink", outlink=link)
                 return frozenset(out)
             else:
                 # no links found
                 return frozenset()
         else:
             self.logger.error(
-                "problem extracting outlinks, result message: %s", message
+                "problem extracting outlinks", message=message
             )
             return frozenset()
 
@@ -791,7 +790,7 @@ class Browser:
         while True:
             elapsed = time.time() - start
             if elapsed > timeout:
-                logging.info("behavior reached hard timeout after %.1fs", elapsed)
+                self.logger.info("behavior reached hard timeout", elapsed=elapsed)
                 return
 
             brozzler.sleep(check_interval)

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -53,7 +53,7 @@ class BrowserPool:
     debugging protocol.
     """
 
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     def __init__(self, size=3, **kwargs):
         """
@@ -144,7 +144,7 @@ class BrowserPool:
 
 
 class WebsockReceiverThread(threading.Thread):
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     def __init__(self, websock, name=None, daemon=True):
         super().__init__(name=name, daemon=daemon)
@@ -322,7 +322,7 @@ class Browser:
     Manages an instance of Chrome for browsing pages.
     """
 
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     def __init__(self, **kwargs):
         """

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -268,7 +268,7 @@ class Chrome:
                     url_logger.warning(
                         "problem accessing url (will keep trying until timeout)",
                         timeout=timeout_sec,
-                        exc_info=True
+                        exc_info=True,
                     )
                     self._last_warning = time.time()
             finally:

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -65,7 +65,7 @@ def check_version(chrome_exe):
 
 
 class Chrome:
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     def __init__(self, chrome_exe, port=9222, ignore_cert_errors=False):
         """

--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -267,7 +267,7 @@ class Chrome:
                 if time.time() - self._last_warning > 30:
                     url_logger.warning(
                         "problem accessing url (will keep trying until timeout)",
-                        timeout=timeout_sec,
+                        timeout_sec=timeout_sec,
                         exc_info=True,
                     )
                     self._last_warning = time.time()

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -112,6 +112,21 @@ def rethinker(args):
 
 
 def configure_logging(args):
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
+            structlog.dev.ConsoleRenderer()
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(args.log_level),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=False
+    )
+
     logging.basicConfig(
         stream=sys.stderr,
         level=args.log_level,

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -417,7 +417,7 @@ def brozzle_page(argv=None):
             on_screenshot=on_screenshot,
             enable_youtube_dl=not args.skip_youtube_dl,
         )
-        logger.info("outlinks: \n\t%s", "\n\t".join(sorted(outlinks)))
+        logger.info("outlinks", outlinks=sorted(outlinks))
     except brozzler.ReachedLimit as e:
         logger.exception("reached limit")
     except brozzler.PageInterstitialShown as e:

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -128,6 +128,8 @@ def configure_logging(args):
         cache_logger_on_first_use=False,
     )
 
+    # We still configure logging for now because its handlers
+    # are used for the gunicorn spawned by the brozzler dashboard.
     logging.basicConfig(
         stream=sys.stderr,
         level=args.log_level,

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -43,7 +43,7 @@ import rethinkdb as rdb
 
 r = rdb.RethinkDB()
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(logger_name=__name__)
 
 
 def add_common_options(arg_parser, argv=None):

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -137,7 +137,7 @@ def configure_logging(args):
             structlog.processors.add_log_level,
             structlog.processors.StackInfoRenderer(),
             structlog.dev.set_exc_info,
-            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=True),
             structlog.processors.CallsiteParameterAdder(
                 [
                     structlog.processors.CallsiteParameter.FILENAME,

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -45,6 +45,7 @@ r = rdb.RethinkDB()
 
 logger = structlog.get_logger()
 
+
 def add_common_options(arg_parser, argv=None):
     argv = argv or sys.argv
     arg_parser.add_argument(
@@ -119,12 +120,12 @@ def configure_logging(args):
             structlog.processors.StackInfoRenderer(),
             structlog.dev.set_exc_info,
             structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
-            structlog.dev.ConsoleRenderer()
+            structlog.dev.ConsoleRenderer(),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(args.log_level),
         context_class=dict,
         logger_factory=structlog.PrintLoggerFactory(),
-        cache_logger_on_first_use=False
+        cache_logger_on_first_use=False,
     )
 
     logging.basicConfig(
@@ -665,7 +666,9 @@ def brozzler_worker(argv=None):
             # make set from seed IDs in SKIP_AV_SEEDS_FILE
             with open(SKIP_AV_SEEDS_FILE) as skips:
                 skip_av_seeds = {int(l) for l in skips.readlines()}
-                logger.info("running with skip_av_seeds file", skip_av_seeds=SKIP_AV_SEEDS_FILE)
+                logger.info(
+                    "running with skip_av_seeds file", skip_av_seeds=SKIP_AV_SEEDS_FILE
+                )
         except Exception as e:
             skip_av_seeds = set()
             logger.info("running with empty skip_av_seeds")
@@ -680,7 +683,7 @@ def brozzler_worker(argv=None):
                 if ytdlp_proxy_endpoints:
                     logger.info(
                         "running with ytdlp proxy endpoints file",
-                        ytdlp_proxy_endpoints=YTDLP_PROXY_ENDPOINTS_FILE
+                        ytdlp_proxy_endpoints=YTDLP_PROXY_ENDPOINTS_FILE,
                     )
         except Exception as e:
             ytdlp_proxy_endpoints = []

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -112,8 +112,9 @@ def rethinker(args):
     return doublethink.Rethinker(servers.split(","), db)
 
 
-# Decorates the logger name with call location, if provided
 def decorate_logger_name(a, b, event_dict):
+    """Decorates the logger name with call location, if provided"""
+
     old_name = event_dict.get("logger_name")
     if old_name is None:
         return event_dict

--- a/brozzler/dashboard/__init__.py
+++ b/brozzler/dashboard/__init__.py
@@ -20,7 +20,7 @@ limitations under the License.
 import structlog
 import sys
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(logger_name=__name__)
 
 try:
     import flask

--- a/brozzler/easy.py
+++ b/brozzler/easy.py
@@ -238,11 +238,14 @@ class BrozzlerEasyController:
         self.logger.info("starting brozzler-worker")
         self.brozzler_worker.start()
 
-        self.logger.info("starting pywb", address="%s:%s" % self.pywb_httpd.server_address)
+        self.logger.info(
+            "starting pywb", address="%s:%s" % self.pywb_httpd.server_address
+        )
         threading.Thread(target=self.pywb_httpd.serve_forever).start()
 
         self.logger.info(
-            "starting brozzler-dashboard", address="%s:%s" % self.dashboard_httpd.server_address
+            "starting brozzler-dashboard",
+            address="%s:%s" % self.dashboard_httpd.server_address,
         )
         threading.Thread(target=self.dashboard_httpd.serve_forever).start()
 

--- a/brozzler/easy.py
+++ b/brozzler/easy.py
@@ -21,6 +21,8 @@ limitations under the License.
 import structlog
 import sys
 
+logger = structlog.get_logger(logger_name=__name__)
+
 try:
     import warcprox
     import warcprox.main
@@ -30,7 +32,7 @@ try:
     import wsgiref.handlers
     import brozzler.dashboard
 except ImportError as e:
-    structlog.get_logger().critical(
+    logger.critical(
         '%s: %s\n\nYou might need to run "pip install '
         'brozzler[easy]".\nSee README.rst for more information.',
         type(e).__name__,
@@ -310,7 +312,7 @@ class BrozzlerEasyController:
             state_strs.append(str(th))
             stack = traceback.format_stack(sys._current_frames()[th.ident])
             state_strs.append("".join(stack))
-        structlog.get_logger().warning(
+        logger.warning(
             "dumping state (caught signal)", signal=signum, state="\n".join(state_strs)
         )
 

--- a/brozzler/easy.py
+++ b/brozzler/easy.py
@@ -156,7 +156,7 @@ class ThreadingWSGIServer(
 
 
 class BrozzlerEasyController:
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     def __init__(self, args):
         self.stop = threading.Event()

--- a/brozzler/frontier.py
+++ b/brozzler/frontier.py
@@ -33,7 +33,7 @@ class UnexpectedDbResult(Exception):
 
 
 class RethinkDbFrontier:
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     def __init__(self, rr, shards=None, replicas=None):
         self.rr = rr

--- a/brozzler/frontier.py
+++ b/brozzler/frontier.py
@@ -50,9 +50,7 @@ class RethinkDbFrontier:
             self.rr.db_create(self.rr.dbname).run()
         tables = self.rr.table_list().run()
         if not "sites" in tables:
-            db_logger.info(
-                "creating rethinkdb table 'sites' in database"
-            )
+            db_logger.info("creating rethinkdb table 'sites' in database")
             self.rr.table_create(
                 "sites", shards=self.shards, replicas=self.replicas
             ).run()
@@ -61,9 +59,7 @@ class RethinkDbFrontier:
             ).run()
             self.rr.table("sites").index_create("job_id").run()
         if not "pages" in tables:
-            db_logger.info(
-                "creating rethinkdb table 'pages' in database"
-            )
+            db_logger.info("creating rethinkdb table 'pages' in database")
             self.rr.table_create(
                 "pages", shards=self.shards, replicas=self.replicas
             ).run()
@@ -83,9 +79,7 @@ class RethinkDbFrontier:
                 [r.row["site_id"], r.row["brozzle_count"], r.row["hops_from_seed"]],
             ).run()
         if not "jobs" in tables:
-            db_logger.info(
-                "creating rethinkdb table 'jobs' in database"
-            )
+            db_logger.info("creating rethinkdb table 'jobs' in database")
             self.rr.table_create(
                 "jobs", shards=self.shards, replicas=self.replicas
             ).run()

--- a/brozzler/model.py
+++ b/brozzler/model.py
@@ -36,7 +36,7 @@ import yaml
 import zlib
 from typing import Optional
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(logger_name=__name__)
 
 
 def load_schema():

--- a/brozzler/model.py
+++ b/brozzler/model.py
@@ -194,7 +194,7 @@ class ElapsedMixIn(object):
 
 
 class Job(doublethink.Document, ElapsedMixIn):
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
     table = "jobs"
 
     def populate_defaults(self):
@@ -223,7 +223,7 @@ class Job(doublethink.Document, ElapsedMixIn):
 
 
 class Site(doublethink.Document, ElapsedMixIn):
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
     table = "sites"
 
     def populate_defaults(self):
@@ -379,7 +379,7 @@ class Site(doublethink.Document, ElapsedMixIn):
 
 
 class Page(doublethink.Document):
-    logger = structlog.get_logger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
     table = "pages"
 
     @staticmethod

--- a/brozzler/model.py
+++ b/brozzler/model.py
@@ -38,6 +38,7 @@ from typing import Optional
 
 logger = structlog.get_logger()
 
+
 def load_schema():
     schema_file = os.path.join(os.path.dirname(__file__), "job_schema.yaml")
     with open(schema_file) as f:

--- a/brozzler/pywb.py
+++ b/brozzler/pywb.py
@@ -19,7 +19,9 @@ limitations under the License.
 """
 
 import sys
-import logging
+import structlog
+
+logger = structlog.get_logger()
 
 try:
     import pywb.apps.cli
@@ -30,7 +32,7 @@ try:
     import pywb.framework.basehandlers
     import pywb.rewrite.wburl
 except ImportError as e:
-    logging.critical(
+    logger.critical(
         '%s: %s\n\nYou might need to run "pip install '
         'brozzler[easy]".\nSee README.rst for more information.',
         type(e).__name__,
@@ -111,7 +113,7 @@ class RethinkCDXSource(pywb.cdx.cdxsource.CDXSource):
         )
         if cdx_query.limit:
             reql = reql.limit(cdx_query.limit)
-        logging.debug("rethinkdb query: %s", reql)
+        logger.debug("rethinkdb query", query=reql)
         results = reql.run()
         return results
 

--- a/brozzler/pywb.py
+++ b/brozzler/pywb.py
@@ -21,7 +21,7 @@ limitations under the License.
 import sys
 import structlog
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(logger_name=__name__)
 
 try:
     import pywb.apps.cli

--- a/brozzler/robots.py
+++ b/brozzler/robots.py
@@ -122,6 +122,6 @@ def is_permitted_by_robots(site, url, proxy=None):
             structlog.get_logger(logger_name=__name__).warning(
                 "returning true (permitted) after problem fetching " "robots.txt",
                 url=url,
-                exception=e,
+                raised_exception=e,
             )
             return True

--- a/brozzler/robots.py
+++ b/brozzler/robots.py
@@ -120,8 +120,7 @@ def is_permitted_by_robots(site, url, proxy=None):
             raise brozzler.ProxyError(e)
         else:
             structlog.get_logger().warning(
-                "returning true (permitted) after problem fetching "
-                "robots.txt",
+                "returning true (permitted) after problem fetching " "robots.txt",
                 url=url,
                 exception=e,
             )

--- a/brozzler/robots.py
+++ b/brozzler/robots.py
@@ -119,7 +119,7 @@ def is_permitted_by_robots(site, url, proxy=None):
             # reppy has wrapped an exception that we want to bubble up
             raise brozzler.ProxyError(e)
         else:
-            structlog.get_logger().warning(
+            structlog.get_logger(logger_name=__name__).warning(
                 "returning true (permitted) after problem fetching " "robots.txt",
                 url=url,
                 exception=e,

--- a/brozzler/robots.py
+++ b/brozzler/robots.py
@@ -23,12 +23,12 @@ limitations under the License.
 """
 
 import json
-import logging
 import brozzler
 import reppy
 import reppy.cache
 import reppy.parser
 import requests
+import structlog
 
 __all__ = ["is_permitted_by_robots"]
 
@@ -119,10 +119,10 @@ def is_permitted_by_robots(site, url, proxy=None):
             # reppy has wrapped an exception that we want to bubble up
             raise brozzler.ProxyError(e)
         else:
-            logging.warning(
+            structlog.get_logger().warning(
                 "returning true (permitted) after problem fetching "
-                "robots.txt for %r: %r",
-                url,
-                e,
+                "robots.txt",
+                url=url,
+                exception=e,
             )
             return True

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -223,13 +223,11 @@ class BrozzlerWorker:
         request.type = "http"
         request.set_proxy(warcprox_address, "http")
 
-
-
         try:
             with urllib.request.urlopen(request, timeout=600) as response:
                 if response.getcode() != 204:
                     self.logger.warning(
-                        'got unexpected response on warcprox '
+                        "got unexpected response on warcprox "
                         "WARCPROX_WRITE_RECORD request (expected 204)",
                         code=response.getcode(),
                         reason=response.reason,
@@ -237,7 +235,7 @@ class BrozzlerWorker:
                 return request, response
         except urllib.error.HTTPError as e:
             self.logger.warning(
-                'got unexpected response on warcprox '
+                "got unexpected response on warcprox "
                 "WARCPROX_WRITE_RECORD request (expected 204)",
                 code=e.getcode(),
                 reason=e.info(),
@@ -326,9 +324,7 @@ class BrozzlerWorker:
                             url=page.url,
                         )
                     else:
-                        self.logger.exception(
-                            "youtube_dl raised exception", page=page
-                        )
+                        self.logger.exception("youtube_dl raised exception", page=page)
         return outlinks
 
     @metrics.brozzler_header_processing_duration_seconds.time()
@@ -581,9 +577,7 @@ class BrozzlerWorker:
                     page=page,
                 )
             else:
-                site_logger.exception(
-                    "unexpected exception", page=page
-                )
+                site_logger.exception("unexpected exception", page=page)
             if page:
                 # Calculate backoff in seconds based on number of failed attempts.
                 # Minimum of 60, max of 135 giving delays of 60, 90, 135, 135...
@@ -687,9 +681,7 @@ class BrozzlerWorker:
                 self._browser_pool.release(browsers[i])
 
     def run(self):
-        self.logger.warn(
-            "brozzler %s - brozzler-worker starting", brozzler.__version__
-        )
+        self.logger.warn("brozzler %s - brozzler-worker starting", brozzler.__version__)
         last_nothing_to_claim = 0
         try:
             while not self._shutdown.is_set():
@@ -698,7 +690,9 @@ class BrozzlerWorker:
                     try:
                         self._start_browsing_some_sites()
                     except brozzler.browser.NoBrowsersAvailable:
-                        self.logger.debug("all browsers are in use", max_browsers=self._max_browsers)
+                        self.logger.debug(
+                            "all browsers are in use", max_browsers=self._max_browsers
+                        )
                     except brozzler.NothingToClaim:
                         last_nothing_to_claim = time.time()
                         self.logger.debug(
@@ -709,9 +703,7 @@ class BrozzlerWorker:
 
             self.logger.warn("shutdown requested")
         except r.ReqlError as e:
-            self.logger.exception(
-                "caught rethinkdb exception, will try to proceed"
-            )
+            self.logger.exception("caught rethinkdb exception, will try to proceed")
         except brozzler.ShutdownRequested:
             self.logger.info("shutdown requested")
         except:
@@ -723,12 +715,11 @@ class BrozzlerWorker:
                 try:
                     self._service_registry.unregister(self.status_info["id"])
                 except:
-                    self.logger.exception(
-                        "failed to unregister from service registry"
-                    )
+                    self.logger.exception("failed to unregister from service registry")
 
             self.logger.info(
-                "shutting down brozzling threads", thread_count=len(self._browsing_threads)
+                "shutting down brozzling threads",
+                thread_count=len(self._browsing_threads),
             )
             with self._browsing_threads_lock:
                 for th in self._browsing_threads:

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -126,7 +126,7 @@ class BrozzlerWorker:
                 self._metrics_port, self._registry_url, self._env
             )
         else:
-            logging.warning(
+            self.logger.warning(
                 "not starting prometheus scrape endpoint: metrics_port is undefined"
             )
 
@@ -190,7 +190,7 @@ class BrozzlerWorker:
                     self._proxy_is_warcprox = status["role"] == "warcprox"
                 except Exception as e:
                     self._proxy_is_warcprox = False
-                logging.info(
+                self.logger.info(
                     "%s %s warcprox",
                     self._proxy,
                     "IS" if self._proxy_is_warcprox else "IS NOT",
@@ -426,7 +426,7 @@ class BrozzlerWorker:
                     video["content-length"] = int(response_headers["content-length"])
                 if "content-range" in response_headers:
                     video["content-range"] = response_headers["content-range"]
-                logging.debug("embedded video %s", video)
+                self.logger.debug("embedded video", video=video)
                 if not "videos" in page:
                     page.videos = []
                 page.videos.append(video)
@@ -537,7 +537,7 @@ class BrozzlerWorker:
                 if page.needs_robots_check and not brozzler.is_permitted_by_robots(
                     site, page.url, self._proxy_for(site)
                 ):
-                    logging.warning("page %s is blocked by robots.txt", page.url)
+                    self.logger.warning("page is blocked by robots.txt", url=page.url)
                     page.blocked_by_robots = True
                     self._frontier.completed_page(site, page)
                 else:

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -18,7 +18,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import logging
 import brozzler
 import brozzler.browser
 import datetime
@@ -31,6 +30,7 @@ import io
 import socket
 import random
 import requests
+import structlog
 import urllib3
 from urllib3.exceptions import TimeoutError, ProxyError
 import doublethink
@@ -45,7 +45,7 @@ r = rdb.RethinkDB()
 
 
 class BrozzlerWorker:
-    logger = logging.getLogger(__module__ + "." + __qualname__)
+    logger = structlog.get_logger()
 
     # 3⅓ min heartbeat interval => 10 min ttl
     # This is kind of a long time, because `frontier.claim_sites()`, which runs
@@ -174,9 +174,9 @@ class BrozzlerWorker:
             site.proxy = "%s:%s" % (svc["host"], svc["port"])
             site.save()
             self.logger.info(
-                "chose warcprox instance %r from service registry for %r",
-                site.proxy,
-                site,
+                "chose warcprox instance from service registry",
+                instance=site.proxy,
+                registry=site,
             )
             return site.proxy
         return None
@@ -223,22 +223,24 @@ class BrozzlerWorker:
         request.type = "http"
         request.set_proxy(warcprox_address, "http")
 
+
+
         try:
             with urllib.request.urlopen(request, timeout=600) as response:
                 if response.getcode() != 204:
                     self.logger.warning(
-                        'got "%s %s" response on warcprox '
+                        'got unexpected response on warcprox '
                         "WARCPROX_WRITE_RECORD request (expected 204)",
-                        response.getcode(),
-                        response.reason,
+                        code=response.getcode(),
+                        reason=response.reason,
                     )
                 return request, response
         except urllib.error.HTTPError as e:
             self.logger.warning(
-                'got "%s %s" response on warcprox '
+                'got unexpected response on warcprox '
                 "WARCPROX_WRITE_RECORD request (expected 204)",
-                e.getcode(),
-                e.info(),
+                code=e.getcode(),
+                reason=e.info(),
             )
             return request, None
         except urllib.error.URLError as e:
@@ -271,16 +273,17 @@ class BrozzlerWorker:
         on_request=None,
         enable_youtube_dl=True,
     ):
-        self.logger.info("brozzling {}".format(page))
+        page_logger = self.logger.bind(page=page)
+        page_logger.info("brozzling")
         outlinks = set()
 
         page_headers = self._get_page_headers(site, page)
 
         if not self._needs_browsing(page_headers):
-            self.logger.info("needs fetch: %s", page)
+            page_logger.info("needs fetch")
             self._fetch_url(site, page=page)
         else:
-            self.logger.info("needs browsing: %s", page)
+            page_logger.info("needs browsing")
             try:
                 browser_outlinks = self._browse_page(
                     browser, site, page, on_screenshot, on_request
@@ -290,7 +293,7 @@ class BrozzlerWorker:
                 if status_code in [502, 504]:
                     raise brozzler.PageConnectionError()
             except brozzler.PageInterstitialShown:
-                self.logger.info("page interstitial shown (http auth): %s", page)
+                page_logger.info("page interstitial shown (http auth)")
 
             if enable_youtube_dl and ydl.should_ytdlp(
                 site, page, status_code, self._skip_av_seeds
@@ -308,10 +311,7 @@ class BrozzlerWorker:
                 except brozzler.ProxyError:
                     raise
                 except brozzler.VideoExtractorError as e:
-                    logging.error(
-                        "error extracting video info: %s",
-                        e,
-                    )
+                    self.logger.exception("error extracting video info")
                 except Exception as e:
                     if (
                         hasattr(e, "exc_info")
@@ -320,26 +320,27 @@ class BrozzlerWorker:
                         and e.exc_info[1].code == 430
                     ):
                         self.logger.info(
-                            "youtube-dl got %s %s processing %s",
-                            e.exc_info[1].code,
-                            e.exc_info[1].msg,
-                            page.url,
+                            "youtube-dl encountered an error",
+                            code=e.exc_info[1].code,
+                            message=e.exc_info[1].msg,
+                            url=page.url,
                         )
                     else:
-                        self.logger.error(
-                            "youtube_dl raised exception on %s", page, exc_info=True
+                        self.logger.exception(
+                            "youtube_dl raised exception", page=page
                         )
         return outlinks
 
     @metrics.brozzler_header_processing_duration_seconds.time()
     @metrics.brozzler_in_progress_headers.track_inprogress()
     def _get_page_headers(self, site, page):
+        url_logger = self.logger.bind(url=page.url)
         # bypassing warcprox, requests' stream=True defers downloading the body of the response
         # see https://docs.python-requests.org/en/latest/user/advanced/#body-content-workflow
         try:
             user_agent = site.get("user_agent")
             headers = {"User-Agent": user_agent} if user_agent else {}
-            self.logger.info("getting page headers for %s", page.url)
+            url_logger.info("getting page headers")
             with requests.get(
                 page.url,
                 stream=True,
@@ -349,11 +350,9 @@ class BrozzlerWorker:
             ) as r:
                 return r.headers
         except requests.exceptions.Timeout as e:
-            self.logger.warning(
-                "Timed out trying to get headers for %s: %s", page.url, e
-            )
+            url_logger.warning("Timed out trying to get headers", exc_info=True)
         except requests.exceptions.RequestException as e:
-            self.logger.warning("Failed to get headers for %s: %s", page.url, e)
+            url_logger.warning("Failed to get headers", exc_info=True)
         return {}
 
     def _needs_browsing(self, page_headers):
@@ -378,10 +377,9 @@ class BrozzlerWorker:
                 on_screenshot(screenshot_jpeg)
             if self._using_warcprox(site):
                 self.logger.info(
-                    "sending WARCPROX_WRITE_RECORD request to %s with "
-                    "screenshot for %s",
-                    self._proxy_for(site),
-                    page,
+                    "sending WARCPROX_WRITE_RECORD request",
+                    proxy=self._proxy_for(site),
+                    screenshot_for_page=page,
                 )
                 thumbnail_jpeg = self.thumb_jpeg(screenshot_jpeg)
                 self._warcprox_write_record(
@@ -437,11 +435,13 @@ class BrozzlerWorker:
 
         def _on_service_worker_version_updated(chrome_msg):
             # https://github.com/internetarchive/brozzler/issues/140
+            # FIXME: `trace` is a custom logging level, need to port
+            #        this over to structlog.
             self.logger.trace("%r", chrome_msg)
             if chrome_msg.get("params", {}).get("versions"):
                 url = chrome_msg.get("params", {}).get("versions")[0].get("scriptURL")
                 if url and url.startswith("http") and url not in sw_fetched:
-                    self.logger.info("fetching service worker script %s", url)
+                    self.logger.info("fetching service worker script", url=url)
                     self._fetch_url(site, url=url)
                     sw_fetched.add(url)
 
@@ -496,7 +496,7 @@ class BrozzlerWorker:
         headers = {"User-Agent": user_agent} if user_agent else {}
         headers.update(site.extra_headers(page))
 
-        self.logger.info("fetching url %s", url)
+        self.logger.info("fetching url", url=url)
         try:
             # response is ignored
             http.request(
@@ -506,17 +506,18 @@ class BrozzlerWorker:
                 timeout=self.FETCH_URL_TIMEOUT,
                 retries=False,
             )
-            self.logger.info("Completed fetching url %s", url)
+            self.logger.info("Completed fetching url", url=url)
         except TimeoutError as e:
-            self.logger.warning("Timed out fetching %s", url)
+            self.logger.warning("Timed out fetching url", url=url)
             raise brozzler.PageConnectionError() from e
         except ProxyError as e:
             raise brozzler.ProxyError("proxy error fetching %s" % url) from e
         except urllib3.exceptions.RequestError as e:
-            self.logger.warning("Failed to fetch url %s: %s", url, e)
+            self.logger.warning("Failed to fetch url", url=url, exc_info=True)
             raise brozzler.PageConnectionError() from e
 
     def brozzle_site(self, browser, site):
+        site_logger = self.logger.bind(site=site)
         try:
             site.last_claimed_by = "%s:%s" % (socket.gethostname(), browser.chrome.port)
             site.save()
@@ -526,9 +527,7 @@ class BrozzlerWorker:
             self._frontier.honor_stop_request(site)
             # _proxy_for() call in log statement can raise brozzler.ProxyError
             # which is why we honor time limit and stop request first☝🏻
-            self.logger.info(
-                "brozzling site (proxy=%r) %s", self._proxy_for(site), site
-            )
+            site_logger.info("brozzling site", proxy=self._proxy_for(site))
             while time.time() - start < self.SITE_SESSION_MINUTES * 60:
                 site.refresh()
                 self._frontier.enforce_time_limit(site)
@@ -556,7 +555,7 @@ class BrozzlerWorker:
         except brozzler.ShutdownRequested:
             self.logger.info("shutdown requested")
         except brozzler.NothingToClaim:
-            self.logger.info("no pages left for site %s", site)
+            site_logger.info("no pages left for site")
         except brozzler.ReachedLimit as e:
             self._frontier.reached_limit(site, e)
         except brozzler.ReachedTimeLimit as e:
@@ -567,28 +566,25 @@ class BrozzlerWorker:
         #     self.logger.info("{} shut down".format(browser))
         except brozzler.ProxyError as e:
             if self._warcprox_auto:
-                logging.error(
-                    "proxy error (site.proxy=%s), will try to choose a "
-                    "healthy instance next time site is brozzled: %s",
-                    site.proxy,
-                    e,
+                self.logger.exception(
+                    "proxy error, will try to choose a "
+                    "healthy instance next time site is brozzled",
+                    site_proxy=site.proxy,
                 )
                 site.proxy = None
             else:
                 # using brozzler-worker --proxy, nothing to do but try the
                 # same proxy again next time
-                logging.error("proxy error (self._proxy=%r)", self._proxy, exc_info=1)
+                self.logger.exception("proxy error", self_proxy=self._proxy)
         except (brozzler.PageConnectionError, Exception) as e:
             if isinstance(e, brozzler.PageConnectionError):
-                self.logger.error(
-                    "Page status code possibly indicates connection failure between host and warcprox: site=%r page=%r",
-                    site,
-                    page,
-                    exc_info=True,
+                site_logger.exception(
+                    "Page status code possibly indicates connection failure between host and warcprox",
+                    page=page,
                 )
             else:
-                self.logger.error(
-                    "unexpected exception site=%r page=%r", site, page, exc_info=True
+                site_logger.exception(
+                    "unexpected exception", page=page
                 )
             if page:
                 # Calculate backoff in seconds based on number of failed attempts.
@@ -600,10 +596,10 @@ class BrozzlerWorker:
                 page.failed_attempts = (page.failed_attempts or 0) + 1
                 if page.failed_attempts >= brozzler.MAX_PAGE_FAILURES:
                     self.logger.info(
-                        'marking page "completed" after %s unexpected '
-                        "exceptions attempting to brozzle %s",
-                        page.failed_attempts,
-                        page,
+                        'marking page "completed" after several unexpected '
+                        "exceptions attempting to brozzle",
+                        failed_attempts=page.failed_attempts,
+                        page=page,
                     )
                     self._frontier.completed_page(site, page)
                     page = None
@@ -641,13 +637,12 @@ class BrozzlerWorker:
 
         try:
             self.status_info = self._service_registry.heartbeat(status_info)
+            # FIXME: need to implement trace
             self.logger.trace("status in service registry: %s", self.status_info)
         except r.ReqlError as e:
-            self.logger.error(
-                "failed to send heartbeat and update service registry "
-                "with info %s: %s",
-                status_info,
-                e,
+            self.logger.exception(
+                "failed to send heartbeat and update service registry",
+                info=status_info,
             )
 
     def _service_heartbeat_if_due(self):
@@ -695,6 +690,7 @@ class BrozzlerWorker:
                 self._browser_pool.release(browsers[i])
 
     def run(self):
+        # FIXME: need to implement notice
         self.logger.notice(
             "brozzler %s - brozzler-worker starting", brozzler.__version__
         )
@@ -717,8 +713,8 @@ class BrozzlerWorker:
 
             self.logger.notice("shutdown requested")
         except r.ReqlError as e:
-            self.logger.error(
-                "caught rethinkdb exception, will try to proceed", exc_info=True
+            self.logger.exception(
+                "caught rethinkdb exception, will try to proceed"
             )
         except brozzler.ShutdownRequested:
             self.logger.info("shutdown requested")
@@ -731,12 +727,12 @@ class BrozzlerWorker:
                 try:
                     self._service_registry.unregister(self.status_info["id"])
                 except:
-                    self.logger.error(
-                        "failed to unregister from service registry", exc_info=True
+                    self.logger.exception(
+                        "failed to unregister from service registry"
                     )
 
             self.logger.info(
-                "shutting down %s brozzling threads", len(self._browsing_threads)
+                "shutting down brozzling threads", thread_count=len(self._browsing_threads)
             )
             with self._browsing_threads_lock:
                 for th in self._browsing_threads:

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -45,7 +45,7 @@ r = rdb.RethinkDB()
 
 
 class BrozzlerWorker:
-    logger = structlog.get_logger()
+    logger = structlog.get_logger(logger_name=__module__ + "." + __qualname__)
 
     # 3⅓ min heartbeat interval => 10 min ttl
     # This is kind of a long time, because `frontier.claim_sites()`, which runs
@@ -739,6 +739,7 @@ class BrozzlerWorker:
                 )
                 return
             self._thread = threading.Thread(target=self.run, name="BrozzlerWorker")
+            self.logger = self.logger.bind(thread=self._thread)
             self._thread.start()
 
     def shutdown_now(self):

--- a/brozzler/ydl.py
+++ b/brozzler/ydl.py
@@ -16,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import logging
 import yt_dlp
 from yt_dlp.utils import match_filter_func, ExtractorError
 import brozzler
@@ -29,6 +28,7 @@ import doublethink
 import datetime
 from . import metrics
 import random
+import structlog
 import threading
 import time
 
@@ -40,14 +40,16 @@ YTDLP_WAIT = 10
 YTDLP_MAX_REDIRECTS = 5
 
 
+logger = structlog.get_logger()
+
 def should_ytdlp(site, page, page_status, skip_av_seeds):
     # called only after we've passed needs_browsing() check
 
     if page_status != 200:
-        logging.info("skipping ytdlp: non-200 page status %s", page_status)
+        logger.info("skipping ytdlp: non-200 page status", page_status=page_status)
         return False
     if site.skip_ytdlp:
-        logging.info("skipping ytdlp: site marked skip_ytdlp")
+        logger.info("skipping ytdlp: site marked skip_ytdlp")
         return False
 
     ytdlp_url = page.redirect_url if page.redirect_url else page.url
@@ -64,7 +66,7 @@ def should_ytdlp(site, page, page_status, skip_av_seeds):
     # TODO: develop UI and refactor
     if ytdlp_seed:
         if site.skip_ytdlp is None and ytdlp_seed in skip_av_seeds:
-            logging.info("skipping ytdlp: site in skip_av_seeds")
+            logger.info("skipping ytdlp: site in skip_av_seeds")
             site.skip_ytdlp = True
             return False
         else:
@@ -112,7 +114,13 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
     """
 
     class _YoutubeDL(yt_dlp.YoutubeDL):
-        logger = logging.getLogger(__module__ + "." + __qualname__)
+        logger = structlog.get_logger(__module__ + "." + __qualname__)
+
+        def __init__(self, url, params=None, auto_init=True):
+            super().__init__(params, auto_init)
+
+            self.url = url
+            self.logger = self.logger.bind(url=url)
 
         def process_ie_result(self, ie_result, download=True, extra_info=None):
             if extra_info is None:
@@ -122,7 +130,7 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
             if result_type in ("url", "url_transparent"):
                 if "extraction_depth" in extra_info:
                     self.logger.info(
-                        f"Following redirect URL: {ie_result['url']} extraction_depth: {extra_info['extraction_depth']}"
+                        f"Following redirect", redirect_url=ie_result['url'], extraction_depth=extra_info['extraction_depth']
                     )
                     extra_info["extraction_depth"] = 1 + extra_info.get(
                         "extraction_depth", 0
@@ -139,8 +147,9 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
         def add_default_extra_info(self, ie_result, ie, url):
             # hook in some logging
             super().add_default_extra_info(ie_result, ie, url)
+            extract_context = self.logger.bind(extractor=ie.IE_NAME)
             if ie_result.get("_type") == "playlist":
-                self.logger.info("extractor %r found playlist in %s", ie.IE_NAME, url)
+                extract_context.info("found playlist")
                 if ie.IE_NAME in {
                     "youtube:playlist",
                     "youtube:tab",
@@ -155,22 +164,20 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
                     try:
                         ie_result["entries_no_dl"] = list(ie_result["entries"])
                     except Exception as e:
-                        self.logger.warning(
-                            "failed to unroll ie_result['entries']? for %s, %s; exception %s",
-                            ie.IE_NAME,
-                            url,
-                            e,
+                        extract_context.warning(
+                            "failed to unroll entries ie_result['entries']?",
+                            exc_info=True
                         )
                         ie_result["entries_no_dl"] = []
                     ie_result["entries"] = []
                     self.logger.info(
-                        "not downloading %s media files from this "
+                        "not downloading media files from this "
                         "playlist because we expect to capture them from "
                         "individual watch/track/detail pages",
-                        len(ie_result["entries_no_dl"]),
+                        media_file_count=len(ie_result["entries_no_dl"]),
                     )
             else:
-                self.logger.info("extractor %r found a download in %s", ie.IE_NAME, url)
+                extract_context.info("found a download")
 
         def _push_video_to_warcprox(self, site, info_dict, postprocessor):
             # 220211 update: does yt-dlp supply content-type? no, not as such
@@ -188,7 +195,7 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
                     mimetype = magic.from_file(info_dict["filepath"], mime=True)
                 except ImportError as e:
                     mimetype = "video/%s" % info_dict["ext"]
-                    self.logger.warning("guessing mimetype %s because %r", mimetype, e)
+                    self.logger.warning("guessing mimetype due to error", mimetype=mimetype, exc_info=True)
 
             # youtube watch page postprocessor is MoveFiles
 
@@ -206,12 +213,11 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
 
             size = os.path.getsize(info_dict["filepath"])
             self.logger.info(
-                "pushing %r video as %s (%s bytes) to " "warcprox at %s with url %s",
-                info_dict["format"],
-                mimetype,
-                size,
-                worker._proxy_for(site),
-                url,
+                "pushing video to warcprox",
+                format=info_dict["format"],
+                mimetype=mimetype,
+                size=size,
+                warcprox=worker._proxy_for(site)
             )
             with open(info_dict["filepath"], "rb") as f:
                 # include content-length header to avoid chunked
@@ -248,24 +254,21 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
             ):
                 worker.logger.debug(
                     "heartbeating site.last_claimed to prevent another "
-                    "brozzler-worker claiming this site id=%r",
-                    site.id,
+                    "brozzler-worker claiming this site",
+                    id=site.id,
                 )
                 site.last_claimed = doublethink.utcnow()
                 site.save()
         except:
             worker.logger.debug(
-                "problem heartbeating site.last_claimed site id=%r",
-                site.id,
+                "problem heartbeating site.last_claimed site",
+                id=site.id,
                 exc_info=True,
             )
 
     def ydl_postprocess_hook(d):
         if d["status"] == "finished":
-            worker.logger.info("[ydl_postprocess_hook] Finished postprocessing")
-            worker.logger.info(
-                "[ydl_postprocess_hook] postprocessor: {}".format(d["postprocessor"])
-            )
+            worker.logger.info("[ydl_postprocess_hook] Finished postprocessing", postprocessor=d["postprocessor"])
             is_youtube_host = isyoutubehost(d["info_dict"]["webpage_url"])
 
             metrics.brozzler_ydl_download_successes.labels(is_youtube_host).inc(1)
@@ -298,7 +301,7 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
         # --cache-dir local or..
         # this looked like a problem with nsf-mounted homedir, maybe not a problem for brozzler on focal?
         "cache_dir": "/home/archiveit",
-        "logger": logging.getLogger("yt_dlp"),
+        "logger": logger,
         "verbose": False,
         "quiet": False,
         # recommended to avoid bot detection
@@ -314,17 +317,16 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
         ytdlp_proxy_for_logs = (
             ydl_opts["proxy"].split("@")[1] if "@" in ydl_opts["proxy"] else "@@@"
         )
-        logging.info("using yt-dlp proxy ... %s", ytdlp_proxy_for_logs)
+        logger.info("using yt-dlp proxy ...", proxy=ytdlp_proxy_for_logs)
 
     # skip warcprox proxying yt-dlp v.2023.07.06: youtube extractor using ranges
     # if worker._proxy_for(site):
     #    ydl_opts["proxy"] = "http://{}".format(worker._proxy_for(site))
 
-    ydl = _YoutubeDL(ydl_opts)
+    ydl = _YoutubeDL(ytdlp_url, params=ydl_opts)
     if site.extra_headers():
         ydl._opener.add_handler(ExtraHeaderAdder(site.extra_headers(page)))
     ydl.pushed_videos = []
-    ydl.url = ytdlp_url
     ydl.is_youtube_host = is_youtube_host
 
     return ydl
@@ -344,7 +346,7 @@ def _remember_videos(page, pushed_videos=None):
             "content-type": pushed_video["content-type"],
             "content-length": pushed_video["content-length"],
         }
-        logging.debug("embedded video %s", video)
+        logger.debug("embedded video", video=video)
         page.videos.append(video)
 
 
@@ -353,7 +355,7 @@ def _try_youtube_dl(worker, ydl, site, page):
     attempt = 0
     while attempt < max_attempts:
         try:
-            logging.info("trying yt-dlp on %s", ydl.url)
+            logger.info("trying yt-dlp", url=ydl.url)
             # should_download_vid = not ydl.is_youtube_host
             # then
             # ydl.extract_info(str(urlcanon.whatwg(ydl.url)), download=should_download_vid)
@@ -394,15 +396,15 @@ def _try_youtube_dl(worker, ydl, site, page):
                 # and others...
                 attempt += 1
                 if attempt == max_attempts:
-                    logging.warning(
-                        "Failed after %s attempt(s). Error: %s", max_attempts, e
+                    logger.warning(
+                        "Failed after %s attempt(s)", max_attempts, attempts=max_attempts, exc_info=True
                     )
                     raise brozzler.VideoExtractorError(
                         "yt-dlp hit error extracting info for %s" % ydl.url
                     )
                 else:
                     retry_wait = min(60, YTDLP_WAIT * (1.5 ** (attempt - 1)))
-                    logging.info(
+                    logger.info(
                         "Attempt %s failed. Retrying in %s seconds...",
                         attempt,
                         retry_wait,
@@ -413,15 +415,15 @@ def _try_youtube_dl(worker, ydl, site, page):
             "yt-dlp hit unknown error extracting info for %s" % ydl.url
         )
 
-    logging.info("ytdlp completed successfully")
+    logger.info("ytdlp completed successfully")
 
     _remember_videos(page, ydl.pushed_videos)
     if worker._using_warcprox(site):
         info_json = json.dumps(ie_result, sort_keys=True, indent=4)
-        logging.info(
+        logger.info(
             "sending WARCPROX_WRITE_RECORD request to warcprox "
-            "with yt-dlp json for %s",
-            ydl.url,
+            "with yt-dlp json",
+            url=ydl.url,
         )
         worker._warcprox_write_record(
             warcprox_address=worker._proxy_for(site),
@@ -452,7 +454,7 @@ def do_youtube_dl(worker, site, page, ytdlp_proxy_endpoints):
     with tempfile.TemporaryDirectory(
         prefix="brzl-ydl-", dir=worker._ytdlp_tmpdir
     ) as tempdir:
-        logging.info("tempdir for yt-dlp: %s", tempdir)
+        logger.info("tempdir for yt-dlp", tempdir=tempdir)
         ydl = _build_youtube_dl(worker, tempdir, site, page, ytdlp_proxy_endpoints)
         ie_result = _try_youtube_dl(worker, ydl, site, page)
         outlinks = set()

--- a/brozzler/ydl.py
+++ b/brozzler/ydl.py
@@ -42,6 +42,7 @@ YTDLP_MAX_REDIRECTS = 5
 
 logger = structlog.get_logger()
 
+
 def should_ytdlp(site, page, page_status, skip_av_seeds):
     # called only after we've passed needs_browsing() check
 
@@ -130,7 +131,9 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
             if result_type in ("url", "url_transparent"):
                 if "extraction_depth" in extra_info:
                     self.logger.info(
-                        f"Following redirect", redirect_url=ie_result['url'], extraction_depth=extra_info['extraction_depth']
+                        f"Following redirect",
+                        redirect_url=ie_result["url"],
+                        extraction_depth=extra_info["extraction_depth"],
                     )
                     extra_info["extraction_depth"] = 1 + extra_info.get(
                         "extraction_depth", 0
@@ -166,7 +169,7 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
                     except Exception as e:
                         extract_context.warning(
                             "failed to unroll entries ie_result['entries']?",
-                            exc_info=True
+                            exc_info=True,
                         )
                         ie_result["entries_no_dl"] = []
                     ie_result["entries"] = []
@@ -195,7 +198,11 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
                     mimetype = magic.from_file(info_dict["filepath"], mime=True)
                 except ImportError as e:
                     mimetype = "video/%s" % info_dict["ext"]
-                    self.logger.warning("guessing mimetype due to error", mimetype=mimetype, exc_info=True)
+                    self.logger.warning(
+                        "guessing mimetype due to error",
+                        mimetype=mimetype,
+                        exc_info=True,
+                    )
 
             # youtube watch page postprocessor is MoveFiles
 
@@ -217,7 +224,7 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
                 format=info_dict["format"],
                 mimetype=mimetype,
                 size=size,
-                warcprox=worker._proxy_for(site)
+                warcprox=worker._proxy_for(site),
             )
             with open(info_dict["filepath"], "rb") as f:
                 # include content-length header to avoid chunked
@@ -268,7 +275,10 @@ def _build_youtube_dl(worker, destdir, site, page, ytdlp_proxy_endpoints):
 
     def ydl_postprocess_hook(d):
         if d["status"] == "finished":
-            worker.logger.info("[ydl_postprocess_hook] Finished postprocessing", postprocessor=d["postprocessor"])
+            worker.logger.info(
+                "[ydl_postprocess_hook] Finished postprocessing",
+                postprocessor=d["postprocessor"],
+            )
             is_youtube_host = isyoutubehost(d["info_dict"]["webpage_url"])
 
             metrics.brozzler_ydl_download_successes.labels(is_youtube_host).inc(1)
@@ -397,7 +407,10 @@ def _try_youtube_dl(worker, ydl, site, page):
                 attempt += 1
                 if attempt == max_attempts:
                     logger.warning(
-                        "Failed after %s attempt(s)", max_attempts, attempts=max_attempts, exc_info=True
+                        "Failed after %s attempt(s)",
+                        max_attempts,
+                        attempts=max_attempts,
+                        exc_info=True,
                     )
                     raise brozzler.VideoExtractorError(
                         "yt-dlp hit error extracting info for %s" % ydl.url
@@ -421,8 +434,7 @@ def _try_youtube_dl(worker, ydl, site, page):
     if worker._using_warcprox(site):
         info_json = json.dumps(ie_result, sort_keys=True, indent=4)
         logger.info(
-            "sending WARCPROX_WRITE_RECORD request to warcprox "
-            "with yt-dlp json",
+            "sending WARCPROX_WRITE_RECORD request to warcprox " "with yt-dlp json",
             url=ydl.url,
         )
         worker._warcprox_write_record(

--- a/brozzler/ydl.py
+++ b/brozzler/ydl.py
@@ -40,7 +40,7 @@ YTDLP_WAIT = 10
 YTDLP_MAX_REDIRECTS = 5
 
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(logger_name=__name__)
 
 
 def should_ytdlp(site, page, page_status, skip_av_seeds):

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setuptools.setup(
         "cryptography>=2.3",
         "python-magic>=0.4.15",
         "prometheus-client>=0.20.0",
-        "structlog>=25.1.0"
+        "structlog>=25.1.0",
     ],
     extras_require={
         "yt-dlp": ["yt-dlp>=2024.7.25"],

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
         "cryptography>=2.3",
         "python-magic>=0.4.15",
         "prometheus-client>=0.20.0",
+        "structlog>=25.1.0"
     ],
     extras_require={
         "yt-dlp": ["yt-dlp>=2024.7.25"],

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -73,11 +73,19 @@ def stop_service(service):
 def httpd(request):
     class RequestHandler(http.server.SimpleHTTPRequestHandler):
         def do_POST(self):
-            logger.info("\n%s\n%s", self.requestline, self.headers)
+            logger.info(
+                "RequestHandler.do_POST",
+                requestline=self.requestline,
+                headers=self.headers,
+            )
             self.do_GET()
 
         def do_GET(self):
-            logger.info("\n%s\n%s", self.requestline, self.headers)
+            logger.info(
+                "RequestHandler.do_GET",
+                requestline=self.requestline,
+                headers=self.headers,
+            )
             if self.path == "/site5/redirect/":
                 self.send_response(303, "See other")
                 self.send_header("Connection", "close")

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -36,7 +36,7 @@ import sys
 import warcprox
 
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(logger_name=__name__)
 
 
 # https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -24,7 +24,6 @@ import os
 import brozzler
 import brozzler.chrome
 import brozzler.ydl
-import logging
 import yaml
 import datetime
 import requests
@@ -35,15 +34,6 @@ import time
 import sys
 import threading
 from unittest import mock
-
-logging.basicConfig(
-    stream=sys.stderr,
-    level=logging.INFO,
-    format=(
-        "%(asctime)s %(process)d %(levelname)s %(threadName)s "
-        "%(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s"
-    ),
-)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This ports the logging from `logging` to `structlog`. I've updated all of the logger instantiations along with all of the places `logging` was called. I've broken out most data that was being inlined into log statements so that it's now structured arguments to the log statements instead. I've also updated at least a few places to add some default parameters that will be included in all logging statements, but I think it'd be good to look at what other common variables we could use to link multiple log statements together. Specifically, at the moment:

* The yt-dlp class always logs the URL
* BrozzlerWorker always logs the thread

To start, I've kept structlog's default formatting. I know we're interested in keeping text-based logs as the default for now; we can talk whatever specifics we'd like. Here's an example of what it looks like at the moment.

```
2025-02-21 09:09:46 [info     ] adding ssurt to scope accept rules [brozzler.model.Site._accept_ssurt_if_not_redundant(model.py:284)] ssurt=com,example,//https:/
2025-02-21 09:09:46 [warning  ] not starting prometheus scrape endpoint: metrics_port is undefined [brozzler.worker.BrozzlerWorker.__init__(worker.py:129)]
2025-02-21 09:09:46 [info     ] running                        [brozzler.chrome.Chrome.start(chrome.py:224)] chrome_args='"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" -v --remote-debugging-port=9222 --remote-allow-origins=http://localhost:9222 --use-mock-keychain --user-data-dir=/var/folders/v9/fhm3y0l12zvbmtpmf39nxm6h0000gn/T/tmp9g9tmai0/chrome-user-data --disable-background-networking --disable-breakpad --disable-renderer-backgrounding --disable-hang-monitor --disable-background-timer-throttling --mute-audio --disable-web-sockets --window-size=1400,900 --no-default-browser-check --disable-first-run-ui --no-first-run --homepage=about:blank --disable-features=HttpsUpgrades --disable-direct-npapi-requests --disable-web-security --disable-notifications --disable-extensions --disable-save-password-bubble --disable-sync --headless=new about:blank'
```

For comparison, the `logging` logs before:

```
2025-02-20 14:02:57,283 9107 INFO MainThread brozzler.model.Site._accept_ssurt_if_not_redundant(model.py:282) adding ssurt com,example,//https:/ to scope accept rules
2025-02-20 14:02:57,283 9107 WARNING MainThread root.__init__(worker.py:129) not starting prometheus scrape endpoint: metrics_port is undefined
2025-02-20 14:02:57,307 9107 INFO MainThread brozzler.chrome.Chrome.start(chrome.py:230) running: '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" -v --remote-debugging-port=9222 --remote-allow-origins=http://localhost:9222 --use-mock-keychain --user-data-dir=/var/folders/v9/fhm3y0l12zvbmtpmf39nxm6h0000gn/T/tmp8pfkm2x7/chrome-user-data --disable-background-networking --disable-breakpad --disable-renderer-backgrounding --disable-hang-monitor --disable-background-timer-throttling --mute-audio --disable-web-sockets --window-size=1400,900 --no-default-browser-check --disable-first-run-ui --no-first-run --homepage=about:blank --disable-features=HttpsUpgrades --disable-direct-npapi-requests --disable-web-security --disable-notifications --disable-extensions --disable-save-password-bubble --disable-sync --headless=new about:blank'
```

I've left the gunicorn logs from brozzler dashboard alone; those seem more difficult to hook into structlog, but also lower priority. As a result, we still configure `logging` in the same place we did before just to ensure that those remaining calls 