### PR TITLE
test: add CI

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,0 +1,22 @@
+name: Full test suite
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # 10PM Pacific daily
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: ./.github/workflows/setup
+
+      - name: Run tests
+        run: |
+          py.test --tb=native --verbose tests

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -1,0 +1,27 @@
+name: Test setup
+
+runs:
+  using: composite
+  steps:
+    - name: Install apt dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install libjpeg-dev chromium-browser
+      shell: bash
+
+    - name: Set up rethinkdb
+      run: |
+        wget -qO- https://download.rethinkdb.com/repository/raw/pubkey.gpg | sudo gpg --dearmor -o /usr/share/keyrings/rethinkdb-archive-keyrings.gpg
+        echo "deb [signed-by=/usr/share/keyrings/rethinkdb-archive-keyrings.gpg] https://download.rethinkdb.com/repository/ubuntu-$(lsb_release -cs) $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+        sudo apt-get update
+        sudo apt-get install rethinkdb
+        sudo cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/instance1.conf
+        sudo /etc/init.d/rethinkdb restart
+      shell: bash
+
+    - name: Install pip dependencies
+      run: |
+        pip install .[rethinkdb,warcprox,yt-dlp]
+        # setuptools required by rethinkdb==2.4.9
+        pip install pytest setuptools
+      shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: ./.github/workflows/setup
+
+      - name: Run tests
+        run: |
+          py.test --tb=native --verbose tests/test_cli.py tests/test_units.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,15 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['3.8', '3.12']
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.version }}
 
       - uses: ./.github/workflows/setup
 

--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -19,9 +19,9 @@ limitations under the License.
 
 import logging
 import structlog
-from pkg_resources import get_distribution as _get_distribution
+from importlib.metadata import version as _version
 
-__version__ = _get_distribution("brozzler").version
+__version__ = _version("brozzler")
 
 
 class ShutdownRequested(Exception):

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -581,7 +581,7 @@ class BrozzlerWorker:
             if page:
                 # Calculate backoff in seconds based on number of failed attempts.
                 # Minimum of 60, max of 135 giving delays of 60, 90, 135, 135...
-                retry_delay = min(135, 60 * (1.5**page.failed_attempts))
+                retry_delay = min(135, 60 * (1.5 ** (page.failed_attempts or 0)))
                 page.retry_after = doublethink.utcnow() + datetime.timedelta(
                     seconds=retry_delay
                 )

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,9 @@ setuptools.setup(
     extras_require={
         "yt-dlp": ["yt-dlp>=2024.7.25"],
         "dashboard": ["flask>=1.0", "gunicorn>=19.8.1"],
+        "warcprox": [
+            "warcprox>=2.4.31",
+        ],
         "rethinkdb": [
             "rethinkdb==2.4.9",
             "doublethink==0.4.9",

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -261,6 +261,7 @@ blocks:
 
 
 # Some changes to the brozzler ydl interface not represented in this test
+# https://github.com/internetarchive/brozzler/issues/330
 @pytest.mark.xfail
 def test_proxy_down():
     """
@@ -474,6 +475,7 @@ def test_thread_raise_second_with_block():
 
 
 # brozzler.ydl.YoutubeDLSpy is missing
+# https://github.com/internetarchive/brozzler/issues/330
 @pytest.mark.xfail
 def test_needs_browsing():
     # only one test case here right now, which exposed a bug

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -260,6 +260,8 @@ blocks:
     )
 
 
+# Some changes to the brozzler ydl interface not represented in this test
+@pytest.mark.xfail
 def test_proxy_down():
     """
     Test all fetching scenarios raise `brozzler.ProxyError` when proxy is down.
@@ -471,6 +473,8 @@ def test_thread_raise_second_with_block():
     assert isinstance(thread_caught_exception, Exception2)
 
 
+# brozzler.ydl.YoutubeDLSpy is missing
+@pytest.mark.xfail
 def test_needs_browsing():
     # only one test case here right now, which exposed a bug
 


### PR DESCRIPTION
This adds two CI runs: a quick one that happens for every pull request and merge to master, and a longer one that happens daily. The long one, in my tests so far, took about six hours(!) - so it's not feasible for us to do on every pull request.

The pull request/master merge tests are all reliably passing right now, but the full suite isn't. I'm not clear if these are legitimate failures, or if it's a sign that some of the code it's testing has changed since it was written. Here's the full test run I ran on it overnight: https://github.com/mistydemeo/brozzler/actions/runs/13534089995/job/37822403796

I added a new installation group to setup.py because the `easy` group isn't currently installable, and some of the dependencies specified there need to be present for the tests to run.