### PR TITLE
deps: remove `easy` group

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,11 +81,7 @@ setuptools.setup(
     extras_require={
         "yt-dlp": ["yt-dlp>=2024.7.25"],
         "dashboard": ["flask>=1.0", "gunicorn>=19.8.1"],
-        "easy": [
-            "warcprox>=2.4.31",
-            "pywb>=0.33.2,<2",
-            "flask>=1.0",
-            "gunicorn>=19.8.1",
+        "rethinkdb": [
             "rethinkdb==2.4.9",
             "doublethink==0.4.9",
         ],


### PR DESCRIPTION
This group isn't actually installable right now because of the jinja dependency conflict.

I've been experimenting with using `uv` for development, and the unsatisfiable `easy` dependencies meant that `uv sync` couldn't work - it needs to be able to resolve the full dependency tree for every group of extras, even if they won't all be installed.