### PR TITLE
Disable OptimizationHints,OptimizationGuideModelDownloading

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -193,7 +193,7 @@ class Chrome:
             "--disable-first-run-ui",
             "--no-first-run",
             "--homepage=about:blank",
-            "--disable-features=HttpsUpgrades",
+            "--disable-features=HttpsUpgrades,OptimizationHints,OptimizationGuideModelDownloading",
             "--disable-direct-npapi-requests",
             "--disable-web-security",
             "--disable-notifications",


### PR DESCRIPTION
Chrome downloads 80MB+ optimisation_guide_model_store by default. We don't need that.