### PR TITLE
__init__.py: rework imports

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -390,6 +390,11 @@ def suggest_default_chrome_exe():
     return "chromium-browser"
 
 
+import datetime
+
+EPOCH_UTC = datetime.datetime.fromtimestamp(0.0, tz=datetime.timezone.utc)
+
+
 from brozzler.robots import is_permitted_by_robots
 from brozzler.browser import Browser, BrowserPool, BrowsingException
 
@@ -404,13 +409,8 @@ __all__ = [
     "suggest_default_chrome_exe",
 ]
 
-import datetime
-
 try:
     import doublethink
-
-    # Synchronize epoch with doublethink if available
-    EPOCH_UTC = datetime.datetime.utcfromtimestamp(0.0).replace(tzinfo=doublethink.UTC)
 
     # All of these imports use doublethink for real and are unsafe
     # to do if doublethink is unavailable.
@@ -440,9 +440,7 @@ try:
         ]
     )
 except ImportError:
-    EPOCH_UTC = datetime.datetime.utcfromtimestamp(0.0).replace(
-        tzinfo=datetime.timezone.utc
-    )
+    pass
 
 # we could make this configurable if there's a good reason
 MAX_PAGE_FAILURES = 3

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -393,7 +393,7 @@ def brozzle_page(argv=None):
             site,
             page,
             on_screenshot=on_screenshot,
-            enable_youtube_dl=not args.skip_youtube_dl,
+            enable_youtube_dl=not worker._skip_youtube_dl,
         )
         logger.info("outlinks", outlinks=sorted(outlinks))
     except brozzler.ReachedLimit as e:

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -95,6 +95,16 @@ class BrozzlerWorker:
         self._skip_extract_outlinks = skip_extract_outlinks
         self._skip_visit_hashtags = skip_visit_hashtags
         self._skip_youtube_dl = skip_youtube_dl
+
+        # We definitely shouldn't ytdlp if the optional extra is missing
+        try:
+            import yt_dlp
+        except ImportError:
+            self.logger.info(
+                "optional yt-dlp extra not installed; setting skip_youtube_dl to True"
+            )
+            self._skip_youtube_dl = True
+
         self._ytdlp_tmpdir = ytdlp_tmpdir
         self._simpler404 = simpler404
         self._screenshot_full_page = screenshot_full_page

--- a/brozzler/ydl.py
+++ b/brozzler/ydl.py
@@ -43,39 +43,6 @@ YTDLP_MAX_REDIRECTS = 5
 logger = structlog.get_logger(logger_name=__name__)
 
 
-def should_ytdlp(site, page, page_status, skip_av_seeds):
-    # called only after we've passed needs_browsing() check
-
-    if page_status != 200:
-        logger.info("skipping ytdlp: non-200 page status", page_status=page_status)
-        return False
-    if site.skip_ytdlp:
-        logger.info("skipping ytdlp: site marked skip_ytdlp")
-        return False
-
-    ytdlp_url = page.redirect_url if page.redirect_url else page.url
-
-    if "chrome-error:" in ytdlp_url:
-        return False
-
-    ytdlp_seed = (
-        site["metadata"]["ait_seed_id"]
-        if "metadata" in site and "ait_seed_id" in site["metadata"]
-        else None
-    )
-
-    # TODO: develop UI and refactor
-    if ytdlp_seed:
-        if site.skip_ytdlp is None and ytdlp_seed in skip_av_seeds:
-            logger.info("skipping ytdlp: site in skip_av_seeds")
-            site.skip_ytdlp = True
-            return False
-        else:
-            site.skip_ytdlp = False
-
-    return True
-
-
 def isyoutubehost(url):
     # split 1 splits scheme from url, split 2 splits path from hostname, split 3 splits query string on hostname
     return "youtube.com" in url.split("//")[-1].split("/")[0].split("?")[0]


### PR DESCRIPTION
Although doublethink is an optional dependency to allow brozzler to be used as a library without it, in practice we had some mandatory import statements that prevented brozzler from being imported without it. This fixes that by gating off some of the imports and exports.

If doublethink is available, brozzler works as it is now. But if it isn't, we make a few changes:

* `brozzler.worker`, `brozzler.cli` and `brozzler.model` reexports are disabled
* One `brozzler.cli` function, which is used outside brozzler's own cli, has been moved into brozzler's `__init__.py`. For compatibility, it's reexported from `brozzler.cli`.