### PR TITLE
Make doublethink and yt-dlp truly optional

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -321,10 +321,9 @@ def _remove_query(url):
 # XXX chop off path after last slash??
 site_surt_canon = urlcanon.Canonicalizer(urlcanon.semantic.steps + [_remove_query])
 
-import doublethink
 import datetime
 
-EPOCH_UTC = datetime.datetime.utcfromtimestamp(0.0).replace(tzinfo=doublethink.UTC)
+EPOCH_UTC = datetime.datetime.fromtimestamp(0.0, tz=datetime.timezone.utc)
 
 # we could make this configurable if there's a good reason
 MAX_PAGE_FAILURES = 3

--- a/brozzler/ydl.py
+++ b/brozzler/ydl.py
@@ -43,37 +43,7 @@ YTDLP_MAX_REDIRECTS = 5
 logger = structlog.get_logger(logger_name=__name__)
 
 
-def should_ytdlp(site, page, page_status, skip_av_seeds):
-    # called only after we've passed needs_browsing() check
 
-    if page_status != 200:
-        logger.info("skipping ytdlp: non-200 page status", page_status=page_status)
-        return False
-    if site.skip_ytdlp:
-        logger.info("skipping ytdlp: site marked skip_ytdlp")
-        return False
-
-    ytdlp_url = page.redirect_url if page.redirect_url else page.url
-
-    if "chrome-error:" in ytdlp_url:
-        return False
-
-    ytdlp_seed = (
-        site["metadata"]["ait_seed_id"]
-        if "metadata" in site and "ait_seed_id" in site["metadata"]
-        else None
-    )
-
-    # TODO: develop UI and refactor
-    if ytdlp_seed:
-        if site.skip_ytdlp is None and ytdlp_seed in skip_av_seeds:
-            logger.info("skipping ytdlp: site in skip_av_seeds")
-            site.skip_ytdlp = True
-            return False
-        else:
-            site.skip_ytdlp = False
-
-    return True
 
 
 def isyoutubehost(url):


### PR DESCRIPTION
While working on updating Umbra, Misty uncovered Brozzler main `__init__.py` unconditionally imports doublethink and yt-dlp, even though these dependencies are listed as optional.

The requirement to import doublethink is resolved by using the standard library to create a timezone aware date time object for the moment of the Unix epoch (that specific second in 1970). It also moves off of the deprecated use of `datetime.utcfromtimestamp`.

The requirement to import yt-dlp is resolved by moving the `should_ytdlp` method to the worker class itself, and conditionally import the `ydl` module if we are going to use it.

I considered moving things from the main `brozzler.__init__.py` but I was concerned that could break code that's not visible to me.