### PR TITLE
deps: add dev deps to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,9 @@ Issues = "https://github.com/internetarchive/brozzler/issues"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = [
+  "pytest>=8.3.5",
+  "ruff>=0.9.9"
+]


### PR DESCRIPTION
This is just a minor tweak. I realized we manually install dev dependencies in a few places, but we didn't explicitly write them down anywhere.