### PR TITLE
CI: extend daily job timeout

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    timeout-minutes: 480
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This was left at the default of six hours, but it timed out last night. I'll set it at eight hours to see if this is more reliable.