### PR TITLE
deps: install setuptools on python 3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,9 @@ setuptools.setup(
         "rethinkdb": [
             "rethinkdb==2.4.9",
             "doublethink==0.4.9",
+            # Needed because of rethinkdb 2.4.9;
+            # can be removed when we can upgrade to 2.4.10.post1
+            "setuptools>=75.8.0;python_version>='3.12'",
         ],
     },
     zip_safe=False,

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 1
 requires-python = ">=3.8"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "blinker"
@@ -171,6 +175,7 @@ dashboard = [
 rethinkdb = [
     { name = "doublethink" },
     { name = "rethinkdb" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
 ]
 warcprox = [
     { name = "warcprox" },
@@ -200,6 +205,7 @@ requires-dist = [
     { name = "reppy", specifier = "==0.3.4" },
     { name = "requests", specifier = ">=2.21" },
     { name = "rethinkdb", marker = "extra == 'rethinkdb'", specifier = "==2.4.9" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and extra == 'rethinkdb'", specifier = ">=75.8.0" },
     { name = "structlog", specifier = ">=25.1.0" },
     { name = "urlcanon", specifier = ">=0.1.dev23" },
     { name = "warcprox", marker = "extra == 'warcprox'", specifier = ">=2.4.31" },
@@ -523,7 +529,7 @@ name = "importlib-metadata"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304 }
 wheels = [
@@ -959,6 +965,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/8f/1f545ea6f9fcd7bf4368551fb91d2064d8f0577b3079bb3f0ae5779fb773/ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029", size = 10247401 },
     { url = "https://files.pythonhosted.org/packages/4f/18/fb703603ab108e5c165f52f5b86ee2aa9be43bb781703ec87c66a5f5d604/ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1", size = 11366360 },
     { url = "https://files.pythonhosted.org/packages/35/85/338e603dc68e7d9994d5d84f24adbf69bae760ba5efd3e20f5ff2cec18da/ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69", size = 10436892 },
+]
+
+[[package]]
+name = "setuptools"
+version = "75.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/53/43d99d7687e8cdef5ab5f9ec5eaf2c0423c2b35133a2b7e7bc276fc32b21/setuptools-75.8.2.tar.gz", hash = "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2", size = 1344083 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/38/7d7362e031bd6dc121e5081d8cb6aa6f6fedf2b67bf889962134c6da4705/setuptools-75.8.2-py3-none-any.whl", hash = "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f", size = 1229385 },
 ]
 
 [[package]]


### PR DESCRIPTION
distutils was removed beginning in Python 3.12, but it's used at runtime by rethinkdb 2.4.9. setuptools provides a copy of distutils, so we should make sure to install it when we're on Python 3.12 or newer until we're able to upgrade to a version of rethinkdb that no longer needs it.

See: https://www.python.org/downloads/release/python-3120/