### PR TITLE
fix: bind worker_id inside BrozzlerWorker

### DIFF
--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -368,6 +368,7 @@ def brozzle_page(argv=None):
         metrics_port=args.metrics_port,
         registry_url=args.registry_url,
         env=args.env,
+        worker_id=args.worker_id,
     )
 
     def on_screenshot(screenshot_jpeg):
@@ -717,6 +718,7 @@ def brozzler_worker(argv=None):
         metrics_port=args.metrics_port,
         registry_url=args.registry_url,
         env=args.env,
+        worker_id=args.worker_id,
     )
 
     signal.signal(signal.SIGQUIT, dump_state)

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -82,6 +82,7 @@ class BrozzlerWorker:
         metrics_port=0,
         registry_url=None,
         env=None,
+        worker_id=None,
     ):
         self._frontier = frontier
         self._service_registry = service_registry
@@ -96,6 +97,9 @@ class BrozzlerWorker:
         self._skip_extract_outlinks = skip_extract_outlinks
         self._skip_visit_hashtags = skip_visit_hashtags
         self._skip_youtube_dl = skip_youtube_dl
+
+        if worker_id is not None:
+            self.logger = self.logger.bind(worker_id=worker_id)
 
         # TODO try using importlib.util.find_spec to test for dependency
         # presence rather than try/except on import.


### PR DESCRIPTION
I'd noticed that the `worker_id` param was missing from `BrozzlerWorker` calls that occurred within a `threading` context. Binding to the local logger instance seems to be more reliable than using global contextvars in this specific case.

Before:

```
2025-03-10 21:03:53 [warning  ] brozzler 1.6.9 - brozzler-worker starting [brozzler.worker.BrozzlerWorker.run(worker.py:732)]
```

After:

```
2025-03-10 21:04:19 [warning  ] brozzler 1.6.9 - brozzler-worker starting [brozzler.worker.BrozzlerWorker.run(worker.py:736)] worker_id=1
```