### PR TITLE
test: fix test brozzler imports

### DIFF
--- a/tests/test_brozzling.py
+++ b/tests/test_brozzling.py
@@ -28,7 +28,7 @@ import urllib
 
 import pytest
 
-import brozzler
+import brozzler.cli
 
 arg_parser = argparse.ArgumentParser()
 brozzler.cli.add_common_options(arg_parser)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -33,7 +33,7 @@ import requests
 import structlog
 import warcprox
 
-import brozzler
+import brozzler.cli
 
 logger = structlog.get_logger(logger_name=__name__)
 

--- a/tests/test_frontier.py
+++ b/tests/test_frontier.py
@@ -26,7 +26,7 @@ import time
 import doublethink
 import pytest
 
-import brozzler
+import brozzler.cli
 
 arg_parser = argparse.ArgumentParser()
 brozzler.cli.add_common_options(arg_parser)


### PR DESCRIPTION
Noticed that the full test run was failing because these tests had an import of just `brozzler`, but they need to call `brozzler.cli`: https://github.com/internetarchive/brozzler/actions/runs/13781502290/job/38540436699