### PR TITLE
CI: add a simple tag-to-release config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  pull_request:
+  push:
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package
+        run: uv publish
+        if: ${{ !github.event.pull_request }}


### PR DESCRIPTION
This adds a tag-to-release Actions config based around `uv`.

This is triggered by pushing a tag with a new version; it will automatically kick off this job, which will publish the new version to PyPI on completion. We can push that tag from a PR or directly to master.

At the moment, this doesn't do anything to automatically create a GitHub release from the tag; we can do that manually for now. We don't currently have in-repo release notes for us to build an automated release from so this would be a largely manual process anyway.

We don't need to provide a token to `uv` to publish; instead, we just need to configure the repo for PyPI access using this: https://docs.pypi.org/trusted-publishers/adding-a-publisher/

cc @vbanos 