### PR TITLE
cli: add thread name to event dict

### DIFF
--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -172,6 +172,8 @@ def configure_logging(args):
                 structlog.processors.CallsiteParameter.FILENAME,
                 structlog.processors.CallsiteParameter.FUNC_NAME,
                 structlog.processors.CallsiteParameter.LINENO,
+                structlog.processors.CallsiteParameter.PROCESS,
+                structlog.processors.CallsiteParameter.THREAD_NAME,
             ],
         ),
         decorate_logger_name,


### PR DESCRIPTION
I missed this item from the old log formatting config in the previous structlog PRs.

Sample (you can see it at the end of the dict):

```
2025-05-02 22:23:55 [info     ] disclaiming                    [brozzler.frontier.RethinkDbFrontier.disclaim_site(frontier.py:326)] site={'active_brozzling_time': 0.025920867919921875, 'behavior_parameters': None, 'claimed': True, 'id': '5b3b5293-596a-4124-b803-ebff954e32de', 'ignore_robots': False, 'last_claimed': datetime.datetime(2025, 5, 2, 22, 23, 55, 114000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x105117140>), 'last_claimed_by': 'Angela.local:54589', 'last_disclaimed': datetime.datetime(2025, 5, 2, 22, 23, 34, 462000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x1051739b0>), 'password': None, 'proxy': None, 'scope': {'accepts': [{'ssurt': 'com,example,//https:/'}]}, 'seed': 'https://example.com', 'skip_ytdlp': None, 'starts_and_stops': [{'start': datetime.datetime(2025, 5, 2, 22, 23, 16, 281000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x105173e90>), 'stop': None}], 'status': 'ACTIVE', 'time_limit': None, 'username': None, 'warcprox_meta': None} thread_name=BrozzlingThread:54589
# eg: thread_name=BrozzlingThread:54589
```

The pre-structlog logs had these at the front, following the log level. For example:

```
DEBUG WebsockThread:58103 root._on_response(worker.py:431)
```