### PR TITLE
ci: two fixes to dependabot action

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,6 +2,7 @@ name: Dependabot
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
@@ -40,7 +41,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Merge PR
-        run: gh pr merge "$PR_URL"
+        run: gh pr merge --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
These were necessary in qa for the automated yt-dlp action to run to completion.

* `contents: write` is necessary to merge a pull request - `pull-requests: write` is for the PR itself, and doesn't grant merge permissions.
* Looks like the merge strategy has to be specified to `gh pr merge` if running in automated mode.