### PR TITLE
brozzler 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brozzler"
-version = "1.6.13"
+version = "1.7.0"
 authors = [
   { name="Noah Levitt", email="nlevitt@archive.org" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ name = "brotlicffi"
 version = "1.1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "implementation_name != 'cpython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/9d/70caa61192f570fcf0352766331b735afa931b4c6bc9a348a0925cc13288/brotlicffi-1.1.0.0.tar.gz", hash = "sha256:b77827a689905143f87915310b93b273ab17888fd43ef350d4832c4a71083c13", size = 465192, upload-time = "2023-09-14T14:22:40.707Z" }
 wheels = [
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "brozzler"
-version = "1.6.13"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "cerberus" },


### PR DESCRIPTION
I chose a series bump for this since it contains a new features, but I can make this 1.6.14 if we prefer.

* Introduces a pair of new capture and exclusion features. A new `video_capture` option at the seed level allows finer-grained control over video capture, and a `pdfs_only` option at the job level allows limiting capture to just PDFs. (#288)
* Updates the yt-dlp dependency so that, when requested, it will always be installed with the `default` and `curl-cffi` extras. (#366)