### PR TITLE
Move classifiers from setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,13 @@ description = "Distributed web crawling with browsers"
 readme = "README.rst"
 requires-python = ">=3.9"
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Operating System :: OS Independent",
+    "Environment :: Console",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: System :: Archiving",
 ]
 dependencies = [
   "PyYAML>=5.1",

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,4 @@ setuptools.setup(
         "brozzler.dashboard": find_package_data("brozzler.dashboard"),
     },
     zip_safe=False,
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Programming Language :: Python :: 3.9",
-        "Topic :: Internet :: WWW/HTTP",
-        "Topic :: System :: Archiving",
-    ],
 )


### PR DESCRIPTION
I realized these were missed when removing the dynamic config in a previous PR.