### PR TITLE
Add `headless` option to Chrome.start

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -146,6 +146,7 @@ class Chrome:
         websocket_timeout=60,
         window_height=900,
         window_width=1400,
+        headless=True,
     ):
         """
         Starts chrome/chromium process.
@@ -203,13 +204,14 @@ class Chrome:
             "--disable-save-password-bubble",
             "--disable-sync",
         ]
-        major_version = check_version(self.chrome_exe)
-        if major_version >= 109:
-            chrome_args.append("--headless=new")
-        elif 96 <= major_version <= 108:
-            chrome_args.append("--headless=chrome")
-        else:
-            chrome_args.append("--headless")
+        if headless:
+            major_version = check_version(self.chrome_exe)
+            if major_version >= 109:
+                chrome_args.append("--headless=new")
+            elif 96 <= major_version <= 108:
+                chrome_args.append("--headless=chrome")
+            else:
+                chrome_args.append("--headless")
 
         extra_chrome_args = os.environ.get("BROZZLER_EXTRA_CHROME_ARGS")
         if extra_chrome_args:

--- a/brozzler/cli.py
+++ b/brozzler/cli.py
@@ -270,6 +270,12 @@ def brozzle_page(argv=None):
     )
     arg_parser.add_argument("--proxy", dest="proxy", default=None, help="http proxy")
     arg_parser.add_argument(
+        "--no-headless",
+        dest="headless",
+        action="store_false",
+        help="Do not run Chrome headlessly",
+    )
+    arg_parser.add_argument(
         "--browser_throughput",
         type=int,
         dest="download_throughput",
@@ -357,6 +363,7 @@ def brozzle_page(argv=None):
     worker = brozzler.BrozzlerWorker(
         frontier=None,
         proxy=args.proxy,
+        headless=args.headless,
         skip_extract_outlinks=args.skip_extract_outlinks,
         skip_visit_hashtags=args.skip_visit_hashtags,
         skip_youtube_dl=args.skip_youtube_dl,
@@ -389,6 +396,7 @@ def brozzle_page(argv=None):
             proxy=args.proxy,
             window_height=args.window_height,
             window_width=args.window_width,
+            headless=args.headless,
         )
         outlinks = worker.brozzle_page(
             browser,
@@ -556,6 +564,12 @@ def brozzler_worker(argv=None):
     )
     arg_parser.add_argument("--proxy", dest="proxy", default=None, help="http proxy")
     arg_parser.add_argument(
+        "--no-headless",
+        dest="headless",
+        action="store_false",
+        help="Do not run Chrome headlessly",
+    )
+    arg_parser.add_argument(
         "--browser_throughput",
         type=int,
         dest="download_throughput",
@@ -694,6 +708,7 @@ def brozzler_worker(argv=None):
         max_browsers=int(args.max_browsers),
         chrome_exe=args.chrome_exe,
         proxy=args.proxy,
+        headless=args.headless,
         warcprox_auto=args.warcprox_auto,
         skip_extract_outlinks=args.skip_extract_outlinks,
         skip_visit_hashtags=args.skip_visit_hashtags,

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -66,6 +66,7 @@ class BrozzlerWorker:
         chrome_exe="chromium-browser",
         warcprox_auto=False,
         proxy=None,
+        headless=True,
         skip_extract_outlinks=False,
         skip_visit_hashtags=False,
         skip_youtube_dl=False,
@@ -93,6 +94,7 @@ class BrozzlerWorker:
         self._proxy = proxy
         assert not (warcprox_auto and proxy)
         self._proxy_is_warcprox = None
+        self._headless = headless
         self._skip_extract_outlinks = skip_extract_outlinks
         self._skip_visit_hashtags = skip_visit_hashtags
         self._skip_youtube_dl = skip_youtube_dl
@@ -510,6 +512,7 @@ class BrozzlerWorker:
                 cookie_db=site.get("cookie_db"),
                 window_height=self._window_height,
                 window_width=self._window_width,
+                headless=self._headless,
             )
         final_page_url, outlinks = browser.browse_page(
             page.url,


### PR DESCRIPTION
Previously, Chrome's headless mode was always turned on. This makes it optional when using Brozzler as a module. (If there's interest in a command-line option for this, I can add that too.)