### PR TITLE
worker: fix possibly-unbound status code

### DIFF
--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -339,6 +339,7 @@ class BrozzlerWorker:
                     raise brozzler.PageConnectionError()
             except brozzler.PageInterstitialShown:
                 page_logger.info("page interstitial shown (http auth)")
+                status_code = -1
 
             if enable_youtube_dl and self.should_ytdlp(
                 page_logger, site, page, status_code


### PR DESCRIPTION
We assigned this inside an exception handler, and allow processing to continue on after catching the exception.