### PR TITLE
ci: test on 3.14 prereleases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['3.9', '3.12']
+        version: ['3.9', '3.12', '3.14']
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
With 3.14 coming up, it'd be a good idea for us to make sure we're testing against the latest version.