### PR TITLE
ci: use uv

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -1,5 +1,9 @@
 name: Test setup
 
+inputs:
+  python-version:
+    required: true
+
 runs:
   using: composite
   steps:
@@ -21,7 +25,5 @@ runs:
 
     - name: Install pip dependencies
       run: |
-        pip install .[rethinkdb,warcprox,yt-dlp]
-        # setuptools required by rethinkdb==2.4.9
-        pip install pytest setuptools
+        uv sync --python ${{ inputs.python-version }} --extra rethinkdb --extra warcprox --extra yt-dlp
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - uses: ./.github/workflows/setup
         with:
           python-version: ${{ matrix.version }}
 
-      - uses: ./.github/workflows/setup
-
       - name: Run tests
         run: |
-          py.test --tb=native --verbose tests/test_cli.py tests/test_units.py
+          uv run py.test --tb=native --verbose tests/test_cli.py tests/test_units.py


### PR DESCRIPTION
My main motivation is that uv provides the Python 3.14 betas, so we can test with those. But this also simplifies the setup steps a bit.