### PR TITLE
ci: test with 3.14 beta

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['3.9', '3.12']
+        version: ['3.9', '3.12', '3.14']
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
3.14 beta 4 is very late in the cycle, so it seems like a good time for us to start testing with it to make sure we're ready.