### PR TITLE
remove unnecessary imports, use find_spec

### DIFF
--- a/brozzler/__init__.py
+++ b/brozzler/__init__.py
@@ -18,6 +18,7 @@ limitations under the License.
 """
 
 import datetime
+import importlib.util
 import logging
 import threading
 from importlib.metadata import version as _version
@@ -414,12 +415,7 @@ __all__ = [
     "suggest_default_chrome_exe",
 ]
 
-# TODO try using importlib.util.find_spec to test for dependency presence
-# rather than try/except on import.
-# See https://docs.astral.sh/ruff/rules/unused-import/#example
-try:
-    import doublethink  # noqa: F401
-
+if importlib.util.find_spec("doublethink"):
     # All of these imports use doublethink for real and are unsafe
     # to do if doublethink is unavailable.
     from brozzler.frontier import RethinkDbFrontier  # noqa: F401
@@ -447,8 +443,6 @@ try:
             "InvalidJobConf",
         ]
     )
-except ImportError:
-    pass
 
 # we could make this configurable if there's a good reason
 MAX_PAGE_FAILURES = 3

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -19,6 +19,7 @@ limitations under the License.
 """
 
 import datetime
+import importlib.util
 import io
 import json
 import socket
@@ -100,14 +101,8 @@ class BrozzlerWorker:
         if worker_id is not None:
             self.logger = self.logger.bind(worker_id=worker_id)
 
-        # TODO try using importlib.util.find_spec to test for dependency
-        # presence rather than try/except on import.
-        # See https://docs.astral.sh/ruff/rules/unused-import/#example
-
         # We definitely shouldn't ytdlp if the optional extra is missing
-        try:
-            import yt_dlp  # noqa: F401
-        except ImportError:
+        if not importlib.util.find_spec("yt_dlp"):
             self.logger.info(
                 "optional yt-dlp extra not installed; setting skip_youtube_dl to True"
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ limitations under the License.
 """
 
 import importlib.metadata
+import importlib.util
 import os
 import subprocess
 
@@ -47,14 +48,12 @@ def console_scripts():
 def cli_commands():
     commands = set(console_scripts().keys())
     commands.remove("brozzler-wayback")
-    try:
-        import gunicorn  # noqa: F401
-    except ImportError:
+    if not importlib.util.find_spec("gunicorn"):
         commands.remove("brozzler-dashboard")
-    try:
-        import pywb  # noqa: F401
-    except ImportError:
+
+    if not importlib.util.find_spec("pywb"):
         commands.remove("brozzler-easy")
+
     return commands
 
 


### PR DESCRIPTION
This was flagged by ruff check - if we just want to find out if a package is available, and don't need to actually import it, we can use importlib.util.find_spec() to resolve it. This can lead to a moderate speedup too, since the import might be slow.