### PR TITLE
tests: fix invalid escape

### DIFF
--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -177,7 +177,7 @@ def test_robots_connection_failure():
 
 def test_scoping():
     test_scope = yaml.safe_load(
-        """
+        r"""
 max_hops: 100
 accepts:
 - url_match: REGEX_MATCH


### PR DESCRIPTION
This made the common mistake of putting `\.` instead of `\\.` in a non-raw string.