### PR TITLE
A few minor tweaks

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -256,7 +256,7 @@ class WebsockReceiverThread(threading.Thread):
                     method="Page.handleJavaScriptDialog",
                     params={"accept": accept},
                 ),
-                separators=",:",
+                separators=(",", ":"),
             )
         )
 
@@ -363,7 +363,7 @@ class Browser:
     def send_to_chrome(self, suppress_logging=False, **kwargs):
         msg_id = next(self._command_id)
         kwargs["id"] = msg_id
-        msg = json.dumps(kwargs, separators=",:")
+        msg = json.dumps(kwargs, separators=(",", ":"))
         self.logger.debug(
             "sending message",
             websock=self.websock,

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -25,6 +25,7 @@ import json
 import socket
 import threading
 import time
+import urllib.error
 import urllib.request
 
 import doublethink


### PR DESCRIPTION
A couple things pyright alterted me to when I was reading something unrelated.

* We were using the wrong type for the `separators` field of `json.dumps`. This is defined as being a tuple, and only works by accident since Python strings are iterable.
* Pyright missed that `urllib.error` got imported transiently via something else. Might as well make it explicit.