### PR TITLE
ci: migrate yt-dlp autotest to renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,4 +1,4 @@
-name: Dependabot
+name: Renovate
 on: pull_request
 
 permissions:
@@ -6,9 +6,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  renovate:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'internetarchive/brozzler'
+    if: github.event.pull_request.user.login == 'renovate[bot]' && github.repository == 'internetarchive/brozzler' && startsWith(github.event.pull_request.head.ref, 'renovate/yt-dlp-')
     steps:
       - uses: actions/checkout@v4
       - name: Install chrome
@@ -30,11 +30,6 @@ jobs:
           uv run scripts/ytdlp_test.py
 
           kill $warcprox_pid
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Auto-approve PR
         run: gh pr review --approve "$PR_URL"
         env:


### PR DESCRIPTION
This replaces the previous yt-dlp auto-test and merge workflow to use Renovate instead of Dependabot, since we've found that Dependabot is no longer able to update our dependencies.

Migrated from the QA branch version.