### PR TITLE
ssl: allow fetching pages needing legacy renegotiation

### DIFF
--- a/brozzler/robots.py
+++ b/brozzler/robots.py
@@ -31,6 +31,7 @@ import requests
 import structlog
 
 import brozzler
+from brozzler.ssl import CustomSSLContextHTTPAdapter, permissive_ssl_context
 
 __all__ = ["is_permitted_by_robots"]
 
@@ -74,6 +75,11 @@ def _robots_cache(site, proxy=None):
     if site.id not in _robots_caches:
         req_sesh = _SessionRaiseOn420()
         req_sesh.verify = False  # ignore cert errors
+
+        ctx = permissive_ssl_context()  # allow unsafe SSL renegotiation
+        ctx.check_hostname = False  # required when verify=False
+        req_sesh.mount("https://", CustomSSLContextHTTPAdapter(ctx))
+
         if proxy:
             proxie = "http://%s" % proxy
             req_sesh.proxies = {"http": proxie, "https": proxie}

--- a/brozzler/ssl.py
+++ b/brozzler/ssl.py
@@ -1,0 +1,25 @@
+import ssl
+
+import requests
+import urllib3
+
+
+class CustomSSLContextHTTPAdapter(requests.adapters.HTTPAdapter):
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = urllib3.poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=self.ssl_context,
+        )
+
+
+def permissive_ssl_context():
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
+
+    return ctx

--- a/brozzler/worker.py
+++ b/brozzler/worker.py
@@ -41,10 +41,49 @@ from urllib3.exceptions import ProxyError, TimeoutError
 import brozzler
 import brozzler.browser
 from brozzler.model import VideoCaptureOptions
+from brozzler.ssl import CustomSSLContextHTTPAdapter, permissive_ssl_context
 
 from . import metrics
 
 r = rdb.RethinkDB()
+
+
+def _get_with_legacy_renegotiation(url, **kwargs) -> requests.Response:
+    """
+    Performs a get request with unsafe legacy renegotiation enabled.
+    """
+    session = requests.session()
+    ctx = permissive_ssl_context()
+    if not kwargs.get("verify", True):
+        ctx.check_hostname = False
+    session.mount("https://", CustomSSLContextHTTPAdapter(ctx))
+    return session.get(url, **kwargs)
+
+
+def _get_with_permissive_fallback(url, **kwargs) -> requests.Response:
+    """
+    Attempts to perform a request with default SSL settings, then falls
+    back to a request with unsafe legacy renegotiation enabled if
+    necessary.
+    """
+    try:
+        return requests.get(url, **kwargs)
+    except requests.exceptions.SSLError as e:
+        if (
+            e.__context__
+            and e.__context__.__context__
+            and e.__context__.__context__.__context__
+            and e.__context__.__context__.__context__.reason
+            == "UNSAFE_LEGACY_RENEGOTIATION_DISABLED"
+        ):
+            logger = structlog.get_logger(logger_name=__name__)
+            logger.info(
+                "request failed with legacy renegotiation disabled; "
+                "retrying with it enabled",
+                url=url,
+            )
+            return _get_with_legacy_renegotiation(url, **kwargs)
+        raise
 
 
 class BrozzlerWorker:
@@ -385,7 +424,7 @@ class BrozzlerWorker:
             user_agent = site.get("user_agent")
             headers = {"User-Agent": user_agent} if user_agent else {}
             url_logger.info("getting page headers")
-            with requests.get(
+            with _get_with_permissive_fallback(
                 page.url,
                 stream=True,
                 verify=False,


### PR DESCRIPTION
Unsafe legacy renegotiation is disabled by default in requests, but it's needed to access some webpages that real browsers are able to safely access. This leaves it disabled by default when fetching headers, while logging and retrying with it enabled if that fails. robots.txt fetching is always done with legacy renegotiation on.

I tested this with a live URL that we'd fail to fetch before, and it works now.

refs https://stackoverflow.com/a/73519818