### PR TITLE
release: 1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ maintainers = [
   { name="Adam Miller", email="adam@archive.org" },
   { name="Barbara Miller", email="barbara@archive.org" },
   { name="Alex Dempsey", email="avdempsey@archive.org" },
+  { name="Misty De Méo", email="misty@archive.org" },
 ]
 description = "Distributed web crawling with browsers"
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brozzler"
-version = "1.7.0"
+version = "1.8.0"
 authors = [
   { name="Noah Levitt", email="nlevitt@archive.org" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -134,7 +134,7 @@ wheels = [
 
 [[package]]
 name = "brozzler"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cerberus" },


### PR DESCRIPTION
I've also presumptively added myself to the maintainers list.

---

This release contains a number of new capture features. It also removes support for Python 3.8.

* The new `--disable-video-capture` commandline flag allows excluding video captures in the `brozzler-new-site` commandline tool. (#379)
* When video capture has been disabled, brozzler will no longer browse YouTube UMP packets. (#378)
* Audio content types are now also skipped when video capture is disabled. (#380)
* It's now possible to control whether Chrome is launched in headless mode using the `--no-headless` commandline flag and the `headless` keyword parameter in the `Chrome.start` method. The default hasn't changed. (#373)
* Improved performance when visiting page anchors. (#394)
* Improved compatibility when fetching `robots.txt` and page headers by enabling legacy renegotiation and disabling errors from unexpected SSL EOFs. (#411)
* Fixed a bug which could break captures under certain specific circumstances when a page interstitial is encountered. (#375)
* The header request timeout has been increased from 30 to 60 seconds. (#367)
* Updated the versions of several dependencies.

Thanks to @TheTechRobo for the features in pull requests #373 and #394!