### PR TITLE
Use chrome -v only when running in DEBUG logging level

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -17,6 +17,7 @@ limitations under the License.
 """
 
 import json
+import logging
 import os
 import re
 import select
@@ -181,7 +182,6 @@ class Chrome:
         new_env["HOME"] = self._home_tmpdir.name
         chrome_args = [
             self.chrome_exe,
-            "-v",
             "--remote-debugging-port=%s" % self.port,
             "--remote-allow-origins=http://localhost:%s" % self.port,
             "--use-mock-keychain",  # mac thing
@@ -206,6 +206,8 @@ class Chrome:
             "--disable-save-password-bubble",
             "--disable-sync",
         ]
+        if self.logger.is_enabled_for(logging.DEBUG):
+            chrome_args.append("-v")
         if headless:
             major_version = check_version(self.chrome_exe)
             if major_version >= 109:


### PR DESCRIPTION
We always use `chrome -v` but `Chrome._read_stderr_stdout()` is processing chrome verbose stdout/stderr outputs and logs them only using `logger.debug`. If not, they are ignored.

We change Chrome init to use `-v` only when the logging level is `DEBUG` to save resources.