### PR TITLE
try-login: allow time for any redirect or scripts

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -620,6 +620,9 @@ class Browser:
                             "login navigated away; returning!", page_url=page_url
                         )
                         self.navigate_to_page(page_url, timeout=page_timeout)
+                    # allow time for any additional redirects or scripts to run after login
+                    time.sleep(10)
+                    self._wait_for_idle(idle_time=5, timeout=4)
                 # If the target page HTTP status is 4xx/5xx, there is no point
                 # in running behaviors, screenshot, outlink and hashtag
                 # extraction as we didn't get a valid page.


### PR DESCRIPTION
Multiple redirects may occur after the login process, especially on JS-heavy pages.