### PR TITLE
Add Chrome CLI flag to prevent auto AI model download

### DIFF
--- a/brozzler/chrome.py
+++ b/brozzler/chrome.py
@@ -198,7 +198,7 @@ class Chrome:
             "--disable-first-run-ui",
             "--no-first-run",
             "--homepage=about:blank",
-            "--disable-features=HttpsUpgrades,HttpsFirstBalancedModeAutoEnable,OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction,OptimizationHints",
+            "--disable-features=HttpsUpgrades,HttpsFirstBalancedModeAutoEnable,OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction,OptimizationGuideOnDeviceModel,OptimizationHints",
             "--disable-direct-npapi-requests",
             "--disable-web-security",
             "--disable-notifications",


### PR DESCRIPTION
Chrome 148 may trigger the download of a ~4GB `weights.bin` file automatically. We want to prevent that.