### PR TITLE
Drop unused cryptography dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
   "urlcanon>=0.1.dev23",
   "cerberus>=1.0.1",
   "jinja2>=2.10",
-  "cryptography>=2.3",
   "python-magic>=0.4.15",
   "prometheus-client>=0.20.0",
   "structlog>=25.1.0",


### PR DESCRIPTION
Added in 2017 (d40390f) as `cryptography!=2.1.1` to work around a broken Ubuntu install of that specific version. The exclusion later mutated into `>=2.3` and the original reason went stale. Nothing in the brozzler source imports cryptography; the warcprox extra still pulls it in transitively for anyone who needs it.