### PR TITLE
Remove monitoring Network.dataReceived to optimise performance

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -303,13 +303,6 @@ class WebsockReceiverThread(threading.Thread):
                             self.active_connections.add(message["params"]["requestId"])
                         self.last_network_activity = time.time()
             elif (
-                message["method"] == "Network.dataReceived"
-                and "params" in message
-                and "requestId" in message["params"]
-            ):
-                with self.activity_lock:
-                    self.last_network_activity = time.time()
-            elif (
                 message["method"] == "Network.loadingFinished"
                 and "params" in message
                 and "requestId" in message["params"]


### PR DESCRIPTION
The more methods we monitor on `_handle_message`, the slower we are. We monitor `Network.dataReceived` to update `self.last_network_activity`.

We also monitor so many `Network` and `Page` events that cover all aspects of requests' lifecycle. We could drop `Network.dataReceived` and miss very little `self.last_network_activity` accuracy.

According to ChatGTP, when we capture a typical page we have the following number of events:
```
| CDP method                           | When triggered                   | Typical frequency per page load |
| ------------------------------------ | -------------------------------- | ------------------------------: |
| `Network.requestWillBeSent`          | Every outgoing HTTP request      |               **50–500+ times** |
| `Network.responseReceived`           | Every response header received   |               **50–500+ times** |
| `Network.dataReceived`               | Every response data chunk        |           **100–10,000+ times** |
| `Network.loadingFinished`            | Every completed request          |               **50–500+ times** |
| `Network.loadingFailed`              | Failed requests                  |                  **0–20 times** |
| `Page.loadEventFired`                | Browser `load` event             |                      **1 time** |
| `Console.messageAdded`               | JS console output                |               **0–1000+ times** |
| `Runtime.exceptionThrown`            | Uncaught JS exceptions           |                      **0–100s** |
| `Page.javascriptDialogOpening`       | alert/confirm/prompt             |                       **0–few** |
| `ServiceWorker.workerVersionUpdated` | Service worker lifecycle changes |                       **0–few** |
| `Inspector.targetCrashed`            | Chrome renderer crash            |                  **0 normally** |
| `Page.interstitialShown`             | HTTP auth/captive portal/etc.    |                  **0 normally** |
```

`Network.dataReceived` is the most frequent method.