### PR TITLE
Use Emulation.setUserAgentOverride instead of deprecated Network method

### DIFF
--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -746,7 +746,7 @@ class Browser:
         )
         if user_agent:
             msg_id = self.send_to_chrome(
-                method="Network.setUserAgentOverride", params={"userAgent": user_agent}
+                method="Emulation.setUserAgentOverride", params={"userAgent": user_agent}
             )
         if download_throughput > -1:
             # traffic shaping already used by SPN2 to aid warcprox resilience

--- a/brozzler/browser.py
+++ b/brozzler/browser.py
@@ -746,7 +746,8 @@ class Browser:
         )
         if user_agent:
             msg_id = self.send_to_chrome(
-                method="Emulation.setUserAgentOverride", params={"userAgent": user_agent}
+                method="Emulation.setUserAgentOverride",
+                params={"userAgent": user_agent},
             )
         if download_throughput > -1:
             # traffic shaping already used by SPN2 to aid warcprox resilience


### PR DESCRIPTION
`Network.setUserAgentOverride` has been deprecated by CDP in favor of `Emulation.setUserAgentOverride`. The params shape used here (`userAgent` only) is identical between the two, so this is a drop-in swap.